### PR TITLE
JWT adapter

### DIFF
--- a/lib/assent/config.ex
+++ b/lib/assent/config.ex
@@ -26,4 +26,13 @@ defmodule Assent.Config do
 
   @doc false
   defdelegate merge(config_a, config_b), to: Keyword
+
+  @doc false
+  @spec json_library(t()) :: module()
+  def json_library(config) do
+    config
+    |> get(:json_library, nil)
+    |> Kernel.||(Application.get_env(:assent, :json_library))
+    |> Kernel.||(Application.get_env(:phoenix, :json_library, Poison))
+  end
 end

--- a/lib/assent/jwt_adapter.ex
+++ b/lib/assent/jwt_adapter.ex
@@ -1,0 +1,37 @@
+defmodule Assent.JWTAdapter do
+  @moduledoc false
+
+  alias Assent.Config
+
+  defmodule JWT do
+    @moduledoc false
+
+    @type t :: %__MODULE__{
+      header: map(),
+      payload: map(),
+      parts: map()
+    }
+
+    defstruct header: nil, payload: nil, parts: nil
+  end
+
+  @callback decode(binary(), Keyword.t()) :: {:ok, JWT.t()} | {:error, any()}
+
+  @doc """
+  Decodes a JSON Web Token
+  """
+  @spec decode(binary(), Keyword.t()) :: {:ok, JWT.t()} | {:error, term()}
+  def decode(token, opts \\ []) do
+    {adapter, opts} = fetch_adapter(opts)
+    adapter.decode(token, opts)
+  end
+
+  defp fetch_adapter(opts) do
+    default_opts = [json_library: Config.json_library(opts)]
+
+    case Keyword.get(opts, :jwt_adapter, Assent.JWTAdapter.AssentJWT) do
+      {adapter, opts} -> {adapter, Keyword.merge(default_opts, opts)}
+      adapter         -> {adapter, default_opts}
+    end
+  end
+end

--- a/lib/assent/jwt_adapter/assent_jwt.ex
+++ b/lib/assent/jwt_adapter/assent_jwt.ex
@@ -1,0 +1,36 @@
+defmodule Assent.JWTAdapter.AssentJWT do
+  @moduledoc """
+  JWT adapter module for parsing JWT tokens.
+  """
+  alias Assent.{Config, JWTAdapter, JWTAdapter.JWT}
+
+  @behaviour Assent.JWTAdapter
+
+  @impl JWTAdapter
+  def decode(token, opts) do
+    with {:ok, json_library} <- Config.fetch(opts, :json_library),
+         {:ok, jwt} <- parse(token, json_library) do
+      {:ok, jwt}
+    end
+  end
+
+  defp parse(token, json_library) do
+    with [header, payload, signature] <- String.split(token, "."),
+         {:ok, header_json} <- Base.decode64(header, padding: false),
+         {:ok, payload_json} <- Base.decode64(payload, padding: false),
+         {:ok, header} <- json_library.decode(header_json),
+         {:ok, payload} <- json_library.decode(payload_json) do
+      {:ok, %JWT{
+        header: header,
+        payload: payload,
+        parts: [
+          header: header_json,
+          payload: payload_json,
+          signature: signature]}}
+    else
+      {:error, error} -> {:error, error}
+      :error          -> {:error, "Couldn't decode base64 string"}
+      _any            -> {:error, "The token is not a JWT"}
+    end
+  end
+end

--- a/lib/assent/jwt_adapter/jose.ex
+++ b/lib/assent/jwt_adapter/jose.ex
@@ -1,0 +1,17 @@
+defmodule Assent.JWTAdapter.JOSE do
+  @moduledoc """
+  JWT adapter module for parsing JWT tokens with JOSE.
+  """
+  alias Assent.{JWTAdapter, JWTAdapter.JWT}
+
+  @behaviour Assent.JWTAdapter
+
+  @impl JWTAdapter
+  def decode(token, json_library: json_library) do
+    JOSE.json_module(json_library)
+
+    {:ok, %JWT{
+      payload: JOSE.JWT.peek_payload(token).fields
+    }}
+  end
+end

--- a/lib/assent/strategies/azure_oauth2.ex
+++ b/lib/assent/strategies/azure_oauth2.ex
@@ -80,5 +80,10 @@ defmodule Assent.Strategy.AzureOAuth2 do
   end
 
   @spec get_user(Config.t(), map()) :: {:ok, map()} | {:error, term()}
-  def get_user(config, token), do: Helpers.decode_jwt(token["id_token"], config)
+  def get_user(config, token) do
+    case Helpers.decode_jwt(token["id_token"], config) do
+      {:ok, jwt}      -> {:ok, jwt.payload}
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/lib/assent/strategy.ex
+++ b/lib/assent/strategy.ex
@@ -98,29 +98,13 @@ defmodule Assent.Strategy do
   Decode a JSON response to a map
   """
   @spec decode_json(binary(), Config.t()) :: {:ok, map()} | {:error, term()}
-  def decode_json(response, config) do
-    json_library = Config.get(config, :json_library, default_json_library())
-    json_library.decode(response)
-  end
-
-  defp default_json_library do
-    Application.get_env(:assent, :json_library) || Application.get_env(:phoenix, :json_library, Poison)
-  end
+  def decode_json(response, config), do: Config.json_library(config).decode(response)
 
   @doc """
-  Decode a JWT token
+  Decodes a JSON Web Token
   """
-  @spec decode_jwt(binary(), Config.t()) :: {:ok, map()} | {:error, term()}
-  def decode_jwt(token, config) do
-    case String.split(token, ".") do
-      [_headers, payload, _signature] ->
-        payload
-        |> Base.decode64!(padding: false)
-        |> decode_json(config)
-      _any ->
-        {:error, "Invalid JWT"}
-    end
-  end
+  @spec decode_jwt(binary(), Config.t()) :: {:ok, %Assent.JWTAdapter.JWT{}} | {:error, term()}
+  def decode_jwt(token, config), do: Assent.JWTAdapter.decode(token, Keyword.take(config, [:json_library, :jwt_adapter]))
 
   @doc """
   Generates a URL

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,8 @@ defmodule Assent.MixProject do
     [
       {:oauther, "~> 1.1"},
 
+      {:jose, "~> 1.8", optional: true},
+
       {:certifi, ">= 0.0.0", optional: true},
       {:ssl_verify_fun, ">= 0.0.0", optional: true},
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "bypass": {:hex, :bypass, "1.0.0", "b78b3dcb832a71aca5259c1a704b2e14b55fd4e1327ff942598b4e7d1a7ad83d", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}], "hexpm"},
   "castore": {:hex, :castore, "0.1.3", "61d720c168d8e3a7d96f188f73d50d7ec79aa619cdabf0acd3782b01ff3a9f10", [:mix], [], "hexpm"},
@@ -9,6 +10,7 @@
   "earmark": {:hex, :earmark, "1.4.1", "07bb382826ee8d08d575a1981f971ed41bd5d7e86b917fd012a93c51b5d28727", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "jose": {:hex, :jose, "1.9.0", "4167c5f6d06ffaebffd15cdb8da61a108445ef5e85ab8f5a7ad926fdf3ada154", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},

--- a/test/assent/jwt_adapter/assent_jwt_test.exs
+++ b/test/assent/jwt_adapter/assent_jwt_test.exs
@@ -1,0 +1,16 @@
+defmodule Assent.JWTAdapter.AssentJWTTest do
+  use ExUnit.Case
+  doctest Assent.JWTAdapter.AssentJWT
+
+  alias Assent.JWTAdapter.{AssentJWT, JWT}
+
+  @jwt "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMzQ1Njc4OTAifQ.fdOPQ05ZfRhkST2-rIWgUpbqUsVhkkNVNcuG7Ki0s-8"
+  @header %{"alg" => "HS256", "typ" => "JWT"}
+  @payload %{"iat" => 1_516_239_022, "name" => "John Doe", "sub" => "1234567890"}
+
+  test "decode/2" do
+    assert {:ok, %JWT{header: header, payload: payload}} = AssentJWT.decode(@jwt, [json_library: Jason])
+    assert header == @header
+    assert payload == @payload
+  end
+end

--- a/test/assent/jwt_adapter/jose_test.exs
+++ b/test/assent/jwt_adapter/jose_test.exs
@@ -1,0 +1,15 @@
+defmodule Assent.JWTAdapter.JOSETest do
+  use ExUnit.Case
+  doctest Assent.JWTAdapter.JOSE
+
+  alias Assent.JWTAdapter.{JOSE, JWT}
+
+  @jwt "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMzQ1Njc4OTAifQ.fdOPQ05ZfRhkST2-rIWgUpbqUsVhkkNVNcuG7Ki0s-8"
+  @payload %{"iat" => 1_516_239_022, "name" => "John Doe", "sub" => "1234567890"}
+
+  test "decode/2" do
+    assert {:ok, %JWT{header: header, payload: payload}} = JOSE.decode(@jwt, [json_library: Jason])
+    assert is_nil(header)
+    assert payload == @payload
+  end
+end


### PR DESCRIPTION
Resolves #3 

This moves out JWT logic to adapter so e.g. JOSE can be used as well. This is part of adding support for JWT signing in #4 