### PR TITLE
Relax mint requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1 (TBA)
+
+* Relax mint requirement
+
 ## v0.1.0 (2019-10-06)
 
 * Initial release

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Assent.MixProject do
       {:certifi, ">= 0.0.0", optional: true},
       {:ssl_verify_fun, ">= 0.0.0", optional: true},
 
-      {:mint, "~> 0.1.0", optional: true},
+      {:mint, ">= 0.1.0 and < 0.5.0", optional: true},
       {:castore, "~> 0.1.0", optional: true},
 
       {:credo, "~> 1.1.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -14,7 +14,7 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
-  "mint": {:hex, :mint, "0.1.0", "f5a82a909bb95a03222e0cfa5384c287f04c271fd2363e81323020cd33c70712", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm"},
+  "mint": {:hex, :mint, "0.4.0", "b93a10192957624ed4a8b8641eff1819019c36487bdf49e2b505afd2cc9b7911", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},

--- a/test/assent/http_adapter/mint_test.exs
+++ b/test/assent/http_adapter/mint_test.exs
@@ -2,6 +2,7 @@ defmodule Assent.HTTPAdapter.MintTest do
   use ExUnit.Case
   doctest Assent.HTTPAdapter.Mint
 
+  alias Mint.TransportError
   alias Assent.HTTPAdapter.{Mint, HTTPResponse}
 
   @expired_certificate_url "https://expired.badssl.com"
@@ -14,11 +15,11 @@ defmodule Assent.HTTPAdapter.MintTest do
   describe "request/4" do
     test "handles SSL" do
       assert {:ok, %HTTPResponse{status: 200}} = Mint.request(:get, @hsts_certificate_url, nil, [])
-      assert {:error, @certificate_expired_error} = Mint.request(:get, @expired_certificate_url, nil, [])
+      assert {:error, %TransportError{reason: @certificate_expired_error}} = Mint.request(:get, @expired_certificate_url, nil, [])
 
       assert {:ok, %HTTPResponse{status: 200}} = Mint.request(:get, @expired_certificate_url, nil, [], transport_opts: [verify: :verify_none])
 
-      assert {:error, :econnrefused} = Mint.request(:get, @unreachable_http_url, nil, [])
+      assert {:error, %TransportError{reason: :econnrefused}} = Mint.request(:get, @unreachable_http_url, nil, [])
     end
   end
 end


### PR DESCRIPTION
Relaxes mint requirement so the newest `0.4.0` version can be used.