### PR TITLE
Proper handling of HTTP/2 in Mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.1 (TBA)
 
 * Relax mint requirement
+* Fix bug in `Assent.HTTPAdapter.Mint` where HTTP/2 responses wasn't parsed correctly
 
 ## v0.1.0 (2019-10-06)
 

--- a/test/assent/http_adapter/mint_test.exs
+++ b/test/assent/http_adapter/mint_test.exs
@@ -21,5 +21,13 @@ defmodule Assent.HTTPAdapter.MintTest do
 
       assert {:error, %TransportError{reason: :econnrefused}} = Mint.request(:get, @unreachable_http_url, nil, [])
     end
+
+    if :crypto.supports()[:curves] do
+      test "handles http/2" do
+        assert {:ok, %HTTPResponse{status: 200}} = Mint.request(:get, "https://http2.golang.org/", nil, [])
+      end
+    else
+      IO.warn("No support curve algorithms, can't test in #{__MODULE__}")
+    end
   end
 end


### PR DESCRIPTION
HTTP/2 server wasn't tested and the response handling was wrong. Now it correctly listens till the request has finished.