### PR TITLE
Use redirect uri from the config in OAuth 2 callback phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 (TBA)
+
+* Require `:redirect_uri` is set in the config of `Assent.Strategy.OAuth2.callback/3` instead of as `redirect_uri` in the params
+
 ## v0.1.1 (2019-10-07)
 
 * Relax mint requirement

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -206,12 +206,13 @@ defmodule Assent.Strategy.OAuth2 do
     end
   end
 
-  defp get_access_token(config, %{"code" => code, "redirect_uri" => redirect_uri}) do
-    auth_method = Config.get(config, :auth_method, :client_secret_basic)
-    token_url = Config.get(config, :token_url, "/oauth/token")
+  defp get_access_token(config, %{"code" => code}) do
+    auth_method  = Config.get(config, :auth_method, :client_secret_basic)
+    token_url    = Config.get(config, :token_url, "/oauth/token")
 
-    with {:ok, site} <- Config.fetch(config, :site),
-         {:ok, auth_headers, auth_body} <- authentication_params(auth_method, config) do
+    with {:ok, site}                    <- Config.fetch(config, :site),
+         {:ok, auth_headers, auth_body} <- authentication_params(auth_method, config),
+         {:ok, redirect_uri}            <- Config.fetch(config, :redirect_uri) do
       headers = [{"content-type", "application/x-www-form-urlencoded"}] ++ auth_headers
       params  = Keyword.merge(auth_body, code: code, redirect_uri: redirect_uri, grant_type: "authorization_code")
       url     = Helpers.to_url(site, token_url)

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -77,7 +77,7 @@ defmodule Assent.Strategy.OAuth2Test do
 
         assert params["grant_type"] == "authorization_code"
         assert params["code"] == "test"
-        assert params["redirect_uri"] == "test"
+        assert params["redirect_uri"] == "http://localhost:4000/auth/callback"
       end)
 
       expect_oauth2_user_request(bypass, @user_api_params)
@@ -91,7 +91,7 @@ defmodule Assent.Strategy.OAuth2Test do
       expect_oauth2_access_token_request(bypass, [], fn _conn, params ->
         assert params["grant_type"] == "authorization_code"
         assert params["code"] == "test"
-        assert params["redirect_uri"] == "test"
+        assert params["redirect_uri"] == "http://localhost:4000/auth/callback"
         assert params["client_id"] == @client_id
         assert params["client_secret"] == @client_secret
       end)
@@ -107,7 +107,7 @@ defmodule Assent.Strategy.OAuth2Test do
       expect_oauth2_access_token_request(bypass, [], fn _conn, params ->
         assert params["grant_type"] == "authorization_code"
         assert params["code"] == "test"
-        assert params["redirect_uri"] == "test"
+        assert params["redirect_uri"] == "http://localhost:4000/auth/callback"
         assert params["client_assertion_type"] == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
         assert {:ok, jwt} = Assent.JWTAdapter.AssentJWT.verify(params["client_assertion"], @client_secret, json_library: Jason)
@@ -136,7 +136,7 @@ defmodule Assent.Strategy.OAuth2Test do
       expect_oauth2_access_token_request(bypass, [], fn _conn, params ->
         assert params["grant_type"] == "authorization_code"
         assert params["code"] == "test"
-        assert params["redirect_uri"] == "test"
+        assert params["redirect_uri"] == "http://localhost:4000/auth/callback"
         assert params["client_assertion_type"] == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
         assert {:ok, jwt} = Assent.JWTAdapter.AssentJWT.verify(params["client_assertion"], @public_key, json_library: Jason)

--- a/test/support/strategies/oauth2_test_case.ex
+++ b/test/support/strategies/oauth2_test_case.ex
@@ -3,7 +3,7 @@ defmodule Assent.Test.OAuth2TestCase do
   use ExUnit.CaseTemplate
 
   setup _tags do
-    params = %{"code" => "test", "redirect_uri" => "test", "state" => "test"}
+    params = %{"code" => "test", "state" => "test"}
     bypass = Bypass.open()
     config = [client_id: "id", client_secret: "secret", site: "http://localhost:#{bypass.port}", redirect_uri: "http://localhost:4000/auth/callback", session_params: %{state: "test"}]
 

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -55,7 +55,7 @@ defmodule Assent.Test.OIDCTestCase do
   }
 
   setup _tags do
-    params = %{"code" => "test", "redirect_uri" => "test", "state" => "test"}
+    params = %{"code" => "test", "state" => "test"}
     bypass = Bypass.open()
     config = [
       client_id: @client_id,


### PR DESCRIPTION
I think this was from some old logic where it was expected to be in params.