### PR TITLE
Capture primary email that is not at head of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3 (TBA)
+
+* Fixed bug in `Assent.Strategy.Github` where multiple emails for account resulted in the verified primary e-mail not being returned
+
 ## v0.1.2 (2019-10-08)
 
 * Require `:redirect_uri` is set in the config of `Assent.Strategy.OAuth2.callback/3` instead of as `redirect_uri` in the params

--- a/lib/assent/strategies/github.ex
+++ b/lib/assent/strategies/github.ex
@@ -82,5 +82,6 @@ defmodule Assent.Strategy.Github do
 
   defp get_primary_email([%{"verified" => true, "primary" => true, "email" => email} | _rest]),
     do: email
+  defp get_primary_email([_ | rest]), do: get_primary_email(rest)
   defp get_primary_email(_any), do: nil
 end

--- a/test/assent/strategies/github_test.exs
+++ b/test/assent/strategies/github_test.exs
@@ -40,9 +40,21 @@ defmodule Assent.Strategy.GithubTest do
   # From https://developer.github.com/v3/users/emails/
   @emails_response [
     %{
+      "email" => "unverifed@github.com",
+      "verified" => false,
+      "primary" => false,
+      "visibility" => "public"
+    },
+    %{
       "email" => "octocat@github.com",
       "verified" => true,
       "primary" => true,
+      "visibility" => "public"
+    },
+    %{
+      "email" => "octocat2@github.com",
+      "verified" => true,
+      "primary" => false,
       "visibility" => "public"
     }
   ]


### PR DESCRIPTION
I have multiple email addresses associated with GitHub and my current "primary email" is number 4 in a list of 6. The current implementation of `get_primary_email/1` assumed the primary email would be at the head of the list. This PR refactors `get_primary_email/1` to now recurse through the whole list. 