### PR TITLE
Add support for no auth method in access token request in OAuth2 strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed unused `:resource` param in `Assent.Strategy.AzureAD`
 * Added "email profile" to scope in `Assent.Strategy.AzureAD`
 * Use `response_mode=form_post` for `Assent.Strategy.AzureAD`
+* Updated `Assent.Strategy.OAuth2` to handle access token request correctly when `:auth_method` is `nil` per RFC specs
 
 ## v0.1.4 (2019-11-09)
 


### PR DESCRIPTION
With the refactoring in #7, there was no longer support for no auth method during access token request. That should be possible though as per https://tools.ietf.org/html/rfc6749#section-4.1.3.

This resolves issue in #23 