### PR TITLE
Use OIDC base strategy for Apple strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Added "email profile" to scope in `Assent.Strategy.AzureAD`
 * Use `response_mode=form_post` for `Assent.Strategy.AzureAD`
 * Updated `Assent.Strategy.OAuth2` to handle access token request correctly when `:auth_method` is `nil` per RFC specs
+* Remove overriden
+* Changed `Assent.Strategy.Apple` to use OIDC strategy and verify the JWT
 
 ## v0.1.4 (2019-11-09)
 

--- a/lib/assent/strategies/apple.ex
+++ b/lib/assent/strategies/apple.ex
@@ -41,18 +41,27 @@ defmodule Assent.Strategy.Apple do
   See https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple
   for more.
   """
-  use Assent.Strategy.OAuth2.Base
+  use Assent.Strategy.OIDC.Base
 
-  alias Assent.{Config, JWTAdapter, Strategy.OAuth2.Base}
+  alias Assent.{Config, JWTAdapter, Strategy.OIDC.Base}
 
   @impl true
-  def default_config(_config) do
+  def default_config(config) do
+    site = Config.get(config, :site, "https://appleid.apple.com")
+
     [
-      site: "https://appleid.apple.com",
-      authorize_url: "/auth/authorize",
-      token_url: "/auth/token",
+      site: site,
+      openid_configuration: %{
+        "issuer" => "https://appleid.apple.com",
+        "id_token_signed_response_alg" => ["RS256"],
+        "authorization_endpoint" => site <> "/auth/authorize",
+        "token_endpoint" => site <> "/auth/token",
+        "jwks_uri" => site <> "/auth/keys",
+        "token_endpoint_auth_methods_supported" => ["client_secret_post"]
+      },
       authorization_params: [scope: "email", response_mode: "form_post"],
-      auth_method: :client_secret_post
+      client_authentication_method: "client_secret_post",
+      openid_default_scope: ""
     ]
   end
 

--- a/lib/assent/strategies/oauth2/base.ex
+++ b/lib/assent/strategies/oauth2/base.ex
@@ -49,8 +49,6 @@ defmodule Assent.Strategy.OAuth2.Base do
       def get_user(config, token), do: OAuth2.get_user(config, token)
 
       defoverridable unquote(__MODULE__)
-
-      defoverridable callback: 2
     end
   end
 

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -49,7 +49,8 @@ defmodule Assent.Strategy.OIDC do
 
   The authorization url will be fetched from the OpenID configuration URI.
 
-  `openid` will automatically be added to the `:scope` in `:authorization_params`.
+  `openid` will automatically be added to the `:scope` in
+  `:authorization_params`, unless `:openid_default_scope` has been set.
 
   Add `:nonce` to the config to pass it with the authorization request. The
   nonce will be returned in `:session_params`. The nonce MUST be session based
@@ -107,15 +108,16 @@ defmodule Assent.Strategy.OIDC do
     new_params =
       config
       |> Config.get(:authorization_params, [])
-      |> add_scope_param()
+      |> add_default_scope_param(config)
       |> add_nonce_param(config)
 
     {:ok, new_params}
   end
 
-  defp add_scope_param(params) do
+  defp add_default_scope_param(params, config) do
     scope     = Config.get(params, :scope, "")
-    new_scope = String.trim("openid #{scope}")
+    default   = Config.get(config, :openid_default_scope, "openid")
+    new_scope = String.trim(default <> " " <> scope)
 
     Config.put(params, :scope, new_scope)
   end

--- a/lib/assent/strategies/oidc/base.ex
+++ b/lib/assent/strategies/oidc/base.ex
@@ -41,6 +41,7 @@ defmodule Assent.Strategy.OIDC.Base do
       def get_user(config, token), do: OIDC.get_user(config, token)
 
       defoverridable unquote(__MODULE__)
+      defoverridable Assent.Strategy
     end
   end
 

--- a/test/assent/strategies/apple_test.exs
+++ b/test/assent/strategies/apple_test.exs
@@ -1,5 +1,5 @@
 defmodule Assent.Strategy.AppleTest do
-  use Assent.Test.OAuth2TestCase
+  use Assent.Test.OIDCTestCase
 
   alias Assent.Strategy.Apple
 
@@ -19,24 +19,75 @@ defmodule Assent.Strategy.AppleTest do
   q9UU8I5mEovUf86QZ7kOBIjJwqnzD1omageEHWwHdBO6B+dFabmdT9POxg==
   -----END PUBLIC KEY-----
   """
-  @id_token "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiYXBwLnRlc3QuY2xpZW50IiwiZXhwIjoxNTY1ODEwNjgyLCJpYXQiOjE1NjU4MTAwODIsInN1YiI6IjAwMTQ3My5mZTZmNmY4M2JmNGI4ZTQ1OTBhYWNiYWJkY2I4NTk4YmQwLjIwMzkiLCJjX2hhc2giOiJoYXNoIiwiZW1haWwiOiJqb2huLmRvZUBleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdXRoX3RpbWUiOjE1NjU4MTAwODJ9.m9NfZG_OcdsoTh0C5AAv_zv8OAtCpf67QhgNANSYY0bXZD4wYfHROSzvKUKs3zsMY_3liV15B4e-fad_6hO2ug"
+  # Based on https://developer.apple.com/documentation/signinwithapplerestapi/authenticating_users_with_sign_in_with_apple
+  @id_token elem(Assent.Strategy.sign_jwt(
+    %{
+      "iss" => "https://appleid.apple.com",
+      "sub" => "001473.fe6f6f83bf4b8e4590aacbabdcb8598bd0.2039",
+      "aud" => @client_id,
+      "exp" => :os.system_time(:second) + 5 * 60,
+      "iat" => :os.system_time(:second),
+      "email" => "john.doe@example.com",
+      "email_verified" => true
+    },
+    "RS256",
+    """
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw
+    kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr
+    m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi
+    NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV
+    3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2
+    QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs
+    kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
+    amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
+    +bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
+    D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
+    0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
+    lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
+    hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
+    bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X
+    +jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B
+    BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC
+    2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx
+    QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz
+    5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9
+    Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0
+    NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j
+    8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma
+    3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K
+    y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB
+    jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=
+    -----END RSA PRIVATE KEY-----
+    """,
+    []), 1)
   @user %{
     "email" => "john.doe@example.com",
     "email_verified" => true,
     "sub" => "001473.fe6f6f83bf4b8e4590aacbabdcb8598bd0.2039"
   }
+  @jwk %{
+    "kty" => "RSA",
+    "kid" => "AIDOPK1",
+    "use" => "sig",
+    "alg" => "RS256",
+    "n" => "nzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA-kzeVOVpVWwkWdVha4s38XM_pa_yr47av7-z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr_Mrm_YtjCZVWgaOYIhwrXwKLqPr_11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e-lf4s4OxQawWD79J9_5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa-GSYOD2QU68Mb59oSk2OB-BtOLpJofmbGEGgvmwyCI9Mw",
+    "e" => "AQAB"
+  }
 
   setup context do
-    config = Keyword.merge(context[:config], [
-      client_id: @client_id,
-      team_id: @team_id,
-      private_key_id: @private_key_id,
-      private_key: @private_key
-    ])
+    config =
+      context[:config]
+      |> Keyword.delete(:openid_configuration)
+      |> Keyword.merge([
+        client_id: @client_id,
+        team_id: @team_id,
+        private_key_id: @private_key_id,
+        private_key: @private_key
+      ])
 
     {:ok, %{context | config: config}}
   end
-
 
   test "authorize_url/2", %{config: config} do
     assert {:ok, %{url: url}} = Apple.authorize_url(config)
@@ -47,7 +98,7 @@ defmodule Assent.Strategy.AppleTest do
 
   if :crypto.supports()[:curves] do
     test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
-      expect_oauth2_access_token_request(bypass, [params: %{access_token: "access_token", id_token: @id_token}, uri: "/auth/token"], fn _conn, params ->
+      expect_oidc_access_token_request(bypass, [id_token: @id_token, uri: "/auth/token"], fn _conn, params ->
         assert {:ok, jwt} = Assent.JWTAdapter.AssentJWT.verify(params["client_secret"], @public_key, json_library: Jason)
         assert jwt.verified?
         assert jwt.header["alg"] == "ES256"
@@ -58,6 +109,8 @@ defmodule Assent.Strategy.AppleTest do
         assert jwt.claims["aud"] == "http://localhost:#{bypass.port}"
         assert jwt.claims["exp"] > DateTime.to_unix(DateTime.utc_now())
       end)
+
+      expect_oidc_jwks_uri_request(bypass, uri: "/auth/keys", keys: [@jwk])
 
       assert {:ok, %{user: user}} = Apple.callback(config, params)
       assert user == @user

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -59,7 +59,6 @@ defmodule Assent.Test.OIDCTestCase do
     bypass = Bypass.open()
     config = [
       client_id: @client_id,
-      client_authentication_method: "client_secret_basic",
       openid_configuration: %{
         "issuer" => "http://localhost:#{bypass.port}",
         "id_token_signed_response_alg" => ["HS256"],


### PR DESCRIPTION
Resolves #21

This uses OIDC rather than OAuth 2 as the base strategy for Apple so the JWT gets verified.