### PR TITLE
Include query params in request using Mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Use `response_mode=form_post` for `Assent.Strategy.AzureAD`
 * Updated `Assent.Strategy.OAuth2` to handle access token request correctly when `:auth_method` is `nil` per RFC specs
 * Changed `Assent.Strategy.Apple` to use OIDC strategy and verify the JWT
+* Fixed bug in `Assent.HTTPAdapter.Mint` with query params not being included in request
 
 ## v0.1.4 (2019-11-09)
 

--- a/lib/assent/http_adapter/mint.ex
+++ b/lib/assent/http_adapter/mint.ex
@@ -15,13 +15,18 @@ defmodule Assent.HTTPAdapter.Mint do
   def request(method, url, body, headers, mint_opts \\ nil) do
     headers = headers ++ [HTTPAdapter.user_agent_header()]
 
-    %{scheme: scheme, port: port, host: host, path: path} = URI.parse(url)
+    %{scheme: scheme, port: port, host: host, path: path, query: query} = URI.parse(url)
+
+    path = add_query_to_path(path, query)
 
     scheme
     |> open_mint_conn(host, port, mint_opts)
     |> mint_request(method, path, headers, body)
     |> format_response()
   end
+
+  defp add_query_to_path(path, query) when is_binary(query), do: path <> "?" <> query
+  defp add_query_to_path(path, _any), do: path
 
   defp open_mint_conn(scheme, host, port, nil), do: open_mint_conn(scheme, host, port, [])
   defp open_mint_conn("http", host, port, opts), do: open_mint_conn(:http, host, port, opts)
@@ -81,5 +86,5 @@ defmodule Assent.HTTPAdapter.Mint do
 
   defp merge_body([{:data, _request, new_body} | rest], body), do: merge_body(rest, body <> new_body)
   defp merge_body(_rest, body), do: body
-  defp merge_body([{:data, _request, _body} | _rest] = responses), do: merge_body(responses, "")
+  defp merge_body(responses), do: merge_body(responses, "")
 end

--- a/test/assent/http_adapter/httpc_test.exs
+++ b/test/assent/http_adapter/httpc_test.exs
@@ -22,6 +22,18 @@ defmodule Assent.HTTPAdapter.HttpcTest do
       assert {:error, {:failed_connect, error}} = Httpc.request(:get, @unreachable_http_url, nil, [])
       assert fetch_inet_error(error) == @unreachable_http_error
     end
+
+    test "handles query in URL" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/get", fn conn ->
+        assert conn.query_string == "a=1"
+
+        Plug.Conn.send_resp(conn, 200, "")
+      end)
+
+      assert {:ok, %HTTPResponse{status: 200}} = Httpc.request(:get, "http://localhost:#{bypass.port}/get?a=1", nil, [])
+    end
   end
 
   defp fetch_inet_error([_, {:inet, [:inet], error}]), do: error

--- a/test/assent/http_adapter/mint_test.exs
+++ b/test/assent/http_adapter/mint_test.exs
@@ -29,5 +29,17 @@ defmodule Assent.HTTPAdapter.MintTest do
     else
       IO.warn("No support curve algorithms, can't test in #{__MODULE__}")
     end
+
+    test "handles query in URL" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/get", fn conn ->
+        assert conn.query_string == "a=1"
+
+        Plug.Conn.send_resp(conn, 200, "")
+      end)
+
+      assert {:ok, %HTTPResponse{status: 200}} = Mint.request(:get, "http://localhost:#{bypass.port}/get?a=1", nil, [])
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/pow-auth/pow_assent/issues/119

Query params was not previously included in the request.