### PR TITLE
Refactor id_token handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Use `response_mode=form_post` for `Assent.Strategy.AzureAD`
 * Updated `Assent.Strategy.OAuth2` to handle access token request correctly when `:auth_method` is `nil` per RFC specs
 * Changed `Assent.Strategy.Apple` to use OIDC strategy and verify the JWT
+* Changed `Assent.Strategy.OIDC` to update token with the expanded JWT as the `id_token`
 * Fixed bug in `Assent.HTTPAdapter.Mint` with query params not being included in request
 
 ## v0.1.4 (2019-11-09)

--- a/lib/assent/strategies/apple.ex
+++ b/lib/assent/strategies/apple.ex
@@ -112,9 +112,6 @@ defmodule Assent.Strategy.Apple do
   def normalize(_config, user), do: {:ok, user}
 
   @impl true
-  def get_user(config, token) do
-    with {:ok, jwt} <- Helpers.verify_jwt(token["id_token"], nil, config) do
-      {:ok, jwt.claims}
-    end
-  end
+  def get_user(_config, %{"id_token" => %{claims: claims}}),
+    do: {:ok, claims}
 end

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -69,10 +69,6 @@ defmodule Assent.Strategy.AzureAD do
   def normalize(_config, user), do: {:ok, user}
 
   @impl true
-  def get_user(config, token) do
-    case Helpers.verify_jwt(token["id_token"], nil, config) do
-      {:ok, jwt}      -> {:ok, jwt.claims}
-      {:error, error} -> {:error, error}
-    end
-  end
+  def get_user(_config, %{"id_token" => %{claims: claims}}),
+    do: {:ok, claims}
 end

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -247,7 +247,7 @@ defmodule Assent.Strategy.OAuth2 do
     config
     |> strategy.get_user(token)
     |> case do
-      {:ok, user} -> {:ok, %{token: token, user: user}}
+      {:ok, user}     -> {:ok, %{token: token, user: user}}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -203,7 +203,7 @@ defmodule Assent.Strategy.OIDC do
          {:ok, jwt}           <- validate_id_token(token["id_token"], openid_config, config) do
       case strategy do
         __MODULE__ -> fetch_and_normalize_userinfo(openid_config, config, token, jwt.claims)
-        strategy   -> strategy.get_user(config, token)
+        strategy   -> strategy.get_user(config, Map.put(token, "id_token", jwt))
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/pow-auth/assent/issues/21#issuecomment-554602009

Now the expanded JWT will be added as `id_token` to the token map so it's no longer necessary to expand the `id_token`.