### PR TITLE
Update docs

### DIFF
--- a/lib/assent/strategies/auth0.ex
+++ b/lib/assent/strategies/auth0.ex
@@ -9,6 +9,8 @@ defmodule Assent.Strategy.Auth0 do
         client_secret: "REPLACE_WITH_CLIENT_SECRET",
         domain: "REPLACE_WITH_DOMAIN"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/basecamp.ex
+++ b/lib/assent/strategies/basecamp.ex
@@ -11,6 +11,8 @@ defmodule Assent.Strategy.Basecamp do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/discord.ex
+++ b/lib/assent/strategies/discord.ex
@@ -8,6 +8,8 @@ defmodule Assent.Strategy.Discord do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/facebook.ex
+++ b/lib/assent/strategies/facebook.ex
@@ -15,6 +15,8 @@ defmodule Assent.Strategy.Facebook do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/github.ex
+++ b/lib/assent/strategies/github.ex
@@ -14,6 +14,8 @@ defmodule Assent.Strategy.Github do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/gitlab.ex
+++ b/lib/assent/strategies/gitlab.ex
@@ -8,6 +8,8 @@ defmodule Assent.Strategy.Gitlab do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/google.ex
+++ b/lib/assent/strategies/google.ex
@@ -12,6 +12,8 @@ defmodule Assent.Strategy.Google do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/instagram.ex
+++ b/lib/assent/strategies/instagram.ex
@@ -8,6 +8,8 @@ defmodule Assent.Strategy.Instagram do
         client_id: "REPLACE_WITH_CLIENT_ID",
         client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth2` for more.
   """
   use Assent.Strategy.OAuth2.Base
 

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -18,6 +18,9 @@ defmodule Assent.Strategy.OIDC do
       not defined
     - `:id_token_ttl_seconds` - The number of seconds from `iat` that an ID
       Token will be considered valid, optional, defaults to nil
+    - `:nonce` - The nonce to use for authorization request, optional, MUST be
+      session based and unguessable. PowAssent will dynamically generate one
+      for the session if set to `true`.
 
   See `Assent.Strategy.OAuth2` for more configuration options.
 

--- a/lib/assent/strategies/twitter.ex
+++ b/lib/assent/strategies/twitter.ex
@@ -8,6 +8,8 @@ defmodule Assent.Strategy.Twitter do
         consumer_key: "REPLACE_WITH_CONSUMER_KEY",
         consumer_secret: "REPLACE_WITH_CONSUMER_SECRET"
       ]
+
+  See `Assent.Strategy.OAuth` for more.
   """
   use Assent.Strategy.OAuth.Base
 


### PR DESCRIPTION
Adds a section on `:nonce` to the OIDC strategy, and short notice about PowAssent's `nonce: true`.