### PR TITLE
Remove `id_token` from `response_type` and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6 (TBA)
+
+* `Assent.Strategy.AzureAD` now uses auth code flow instead of hybrid flow
+
 ## v0.1.5 (2020-01-13)
 
 * Removed unused `:resource` param in `Assent.Strategy.AzureAD`

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -4,33 +4,15 @@ defmodule Assent.Strategy.AzureAD do
 
   ## Configuration
 
-  - `:client_id` - The OAuth2 client id, required
   - `:tenant_id` - The Azure tenant ID, optional, defaults to `common`
-  - `:nonce` - The session based nonce, required
 
   See `Assent.Strategy.OIDC` for more.
-
-  ## Nonce
-
-  You must provide a `:nonce` in your config when calling `authorize_url/1`.
-  `:nonce` will be returned in the `:session_params` along with `:state`. You
-  can use this to store the value in the current session e.g. a HTTPOnly
-  session cookie.
-
-  A random value generator could look like this:
-
-      16
-      |> :crypto.strong_rand_bytes()
-      |> Base.encode64(padding: false)
-
-  The `:session_params` should be fetched before the callback. See
-  `Assent.Strategy.OIDC.authorize_url/1` for more.
 
   ## Usage
 
       config = [
         client_id: "REPLACE_WITH_CLIENT_ID",
-        nonce: "DYNAMICALLY_REPLACE_WITH_SESSION_NONCE"
+        client_secret: "REPLACE_WITH_CLIENT_SECRET"
       ]
 
   A tenant id can be set to limit scope of users who can get access (defaults
@@ -38,7 +20,7 @@ defmodule Assent.Strategy.AzureAD do
 
       config = [
         client_id: "REPLACE_WITH_CLIENT_ID",
-        nonce: "DYNAMICALLY_REPLACE_WITH_SESSION_NONCE",
+        client_secret: "REPLACE_WITH_CLIENT_SECRET",
         tenant_id: "REPLACE_WITH_TENANT_ID"
       ]
 
@@ -60,7 +42,7 @@ defmodule Assent.Strategy.AzureAD do
 
     [
       site: "https://login.microsoftonline.com/#{tenant_id}/v2.0",
-      authorization_params: [response_type: "id_token code", scope: "email profile", response_mode: "form_post"],
+      authorization_params: [scope: "email profile", response_mode: "form_post"],
       client_auth_method: :client_secret_post,
     ]
   end

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -13,14 +13,16 @@ defmodule Assent.Strategy.OIDC do
       defaults to `/.well-known/openid-configuration`
     - `:client_authentication_method` - The Client Authentication method to
       use, optional, defaults to `client_secret_basic`
+    - `:client_secret` - The client secret, required if
+      `:client_authentication_method` is `:client_secret_basic`,
+      `:client_secret_post`, or `:client_secret_jwt`
     - `:openid_configuration` - The OpenID configuration, optional, the
       configuration will be fetched from `:openid_configuration_uri` if this is
       not defined
     - `:id_token_ttl_seconds` - The number of seconds from `iat` that an ID
       Token will be considered valid, optional, defaults to nil
     - `:nonce` - The nonce to use for authorization request, optional, MUST be
-      session based and unguessable. PowAssent will dynamically generate one
-      for the session if set to `true`.
+      session based and unguessable
 
   See `Assent.Strategy.OAuth2` for more configuration options.
 
@@ -41,6 +43,23 @@ defmodule Assent.Strategy.OIDC do
         config
         |> Assent.Config.put(:session_params, session_params)
         |> Assent.Strategy.OIDC.callback(params)
+
+  ## Nonce
+
+  `:nonce` can be set in the provider config. The `:nonce` will be returned in
+  the `:session_params` along with `:state`. You can use this to store the value
+  in the current session e.g. a httpOnly session cookie.
+
+  A random value generator can look like this:
+
+      16
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode64(padding: false)
+
+  PowAssent will dynamically generate one for the session if `:nonce` is set to
+  `true`.
+
+  See `Assent.Strategy.OIDC.authorize_url/1` for more.
   """
   @behaviour Assent.Strategy
 
@@ -58,7 +77,7 @@ defmodule Assent.Strategy.OIDC do
   Add `:nonce` to the config to pass it with the authorization request. The
   nonce will be returned in `:session_params`. The nonce MUST be session based
   and unguessable. A cryptographic hash of a cryptographically random value
-  could be stored in a HttpOnly session cookie.
+  could be stored in a httpOnly session cookie.
 
   See `Assent.Strategy.OAuth2.authorize_url/1` for more.
   """


### PR DESCRIPTION
Per discussion in #29 this removes the `id_token` from the `response_type` since it's not needed for the code auth flow. I've also updated the docs.