### PR TITLE
Fix handling of email verified for multiple providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.1.8 (TBA)
+
+* `Assent.Strategy.Github` now provides `email_verified` value
+* `Assent.Strategy.Gitlab` now provides `email_verified` value
+* `Assent.Strategy.Google` fixed to provide correct `email_verified` value
+* `Assent.Strategy.Twitter` now provides `email_verified` value
+
 ## v0.1.7 (2020-02-10)
 
 * Fix `Assent.HTTPAdapter.Mint` where `:unknown` responses where not handled correctly

--- a/lib/assent/strategies/basecamp.ex
+++ b/lib/assent/strategies/basecamp.ex
@@ -5,6 +5,9 @@ defmodule Assent.Strategy.Basecamp do
   In the normalized user response a `basecamp_accounts` field is included that
   can be used to limit access to users belonging to a particular account.
 
+  The Basecamp user endpoint does not provide data on email verification, email
+  is considered unverified.
+
   ## Usage
 
       config = [

--- a/lib/assent/strategies/facebook.ex
+++ b/lib/assent/strategies/facebook.ex
@@ -2,6 +2,10 @@ defmodule Assent.Strategy.Facebook do
   @moduledoc """
   Facebook OAuth 2.0 strategy.
 
+  The Facebook user endpoint does not provide data on email verification, email
+  is considered unverified. More here:
+  https://developers.facebook.com/docs/facebook-login/multiple-providers#postfb1
+
   ## Configuration
 
   - `:user_url_request_fields` - The fields for the resource, defaults to
@@ -41,14 +45,14 @@ defmodule Assent.Strategy.Facebook do
   def normalize(config, user) do
     with {:ok, site} <- Config.fetch(config, :site) do
       {:ok, %{
-        "sub"                => user["id"],
-        "name"               => user["name"],
-        "given_name"         => user["first_name"],
-        "middle_name"        => user["middle_name"],
-        "family_name"        => user["last_name"],
-        "profile"            => user["link"],
-        "picture"            => picture_url(site, user),
-        "email"              => user["email"]
+        "sub"         => user["id"],
+        "name"        => user["name"],
+        "given_name"  => user["first_name"],
+        "middle_name" => user["middle_name"],
+        "family_name" => user["last_name"],
+        "profile"     => user["link"],
+        "picture"     => picture_url(site, user),
+        "email"       => user["email"]
       }}
     end
   end

--- a/lib/assent/strategies/github.ex
+++ b/lib/assent/strategies/github.ex
@@ -42,7 +42,8 @@ defmodule Assent.Strategy.Github do
       "preferred_username" => user["login"],
       "profile"            => user["html_url"],
       "picture"            => user["avatar_url"],
-      "email"              => user["email"]
+      "email"              => user["email"],
+      "email_verified"     => user["email_verified"]
     }}
   end
 
@@ -76,14 +77,14 @@ defmodule Assent.Strategy.Github do
   end
 
   defp process_get_email_response({:ok, %{body: emails}}, user) do
-    email = get_primary_email(emails)
+    {email, verified} = get_primary_email(emails)
 
-    {:ok, Map.put(user, "email", email)}
+    {:ok, Map.merge(user, %{"email" => email, "email_verified" => verified})}
   end
   defp process_get_email_response({:error, error}, _user), do: {:error, error}
 
-  defp get_primary_email([%{"verified" => true, "primary" => true, "email" => email} | _rest]),
-    do: email
+  defp get_primary_email([%{"verified" => verified, "primary" => true, "email" => email} | _rest]),
+    do: {email, verified}
   defp get_primary_email([_ | rest]), do: get_primary_email(rest)
-  defp get_primary_email(_any), do: nil
+  defp get_primary_email(_any), do: {nil, false}
 end

--- a/lib/assent/strategies/gitlab.ex
+++ b/lib/assent/strategies/gitlab.ex
@@ -32,7 +32,8 @@ defmodule Assent.Strategy.Gitlab do
       "name"               => user["name"],
       "preferred_username" => user["username"],
       "picture"            => user["avatar_url"],
-      "email"              => user["email"]
+      "email"              => user["email"],
+      "email_verified"     => not is_nil(user["confirmed_at"])
     }}
   end
 end

--- a/lib/assent/strategies/google.ex
+++ b/lib/assent/strategies/google.ex
@@ -38,7 +38,7 @@ defmodule Assent.Strategy.Google do
       "family_name"    => user["family_name"],
       "picture"        => user["picture"],
       "email"          => user["email"],
-      "email_verified" => user["verified_email"],
+      "email_verified" => user["email_verified"],
       "locale"         => user["locale"]
     },
     %{

--- a/lib/assent/strategies/instagram.ex
+++ b/lib/assent/strategies/instagram.ex
@@ -2,6 +2,9 @@ defmodule Assent.Strategy.Instagram do
   @moduledoc """
   Instagram OAuth 2.0 strategy.
 
+  The Instagram user object does not provide data on email verification, email
+  is considered unverified.
+
   ## Usage
 
       config = [

--- a/lib/assent/strategies/slack.ex
+++ b/lib/assent/strategies/slack.ex
@@ -2,6 +2,9 @@ defmodule Assent.Strategy.Slack do
   @moduledoc """
   Slack OAuth 2.0 strategy.
 
+  The Slack user endpoint does not provide data on email verification, email is
+  considered unverified.
+
   ## Configuration
 
   - `:team_id` - The team id to restrict authorization for, optional, defaults to nil

--- a/lib/assent/strategies/twitter.ex
+++ b/lib/assent/strategies/twitter.ex
@@ -2,6 +2,9 @@ defmodule Assent.Strategy.Twitter do
   @moduledoc """
   Twitter OAuth strategy.
 
+  The Twitter user endpoint only returns verified email, `email_verified` will
+  always be `true`.
+
   ## Usage
 
       config = [
@@ -30,7 +33,8 @@ defmodule Assent.Strategy.Twitter do
       "profile"            => "https://twitter.com/#{user["screen_name"]}",
       "picture"            => user["profile_image_url_https"],
       "website"            => user["url"],
-      "email"              => user["email"]
+      "email"              => user["email"],
+      "email_verified"     => true
     }}
   end
 end

--- a/lib/assent/strategies/vk.ex
+++ b/lib/assent/strategies/vk.ex
@@ -2,6 +2,9 @@ defmodule Assent.Strategy.VK do
   @moduledoc """
   VK.com OAuth 2.0 strategy.
 
+  The VK token endpoint does not provide data on email verification, email is
+  considered unverified.
+
   ## Configuration
 
   - `:user_url_params` - Parameters to send along with the user fetch request,

--- a/test/assent/strategies/github_test.exs
+++ b/test/assent/strategies/github_test.exs
@@ -60,6 +60,7 @@ defmodule Assent.Strategy.GithubTest do
   ]
   @user %{
     "email" => "octocat@github.com",
+    "email_verified" => true,
     "name" => "monalisa octocat",
     "picture" => "https://github.com/images/error/octocat_happy.gif",
     "preferred_username" => "octocat",

--- a/test/assent/strategies/gitlab_test.exs
+++ b/test/assent/strategies/gitlab_test.exs
@@ -41,6 +41,7 @@ defmodule Assent.Strategy.GitlabTest do
   }
   @user %{
     "email" => "john@example.com",
+    "email_verified" => true,
     "name" => "John Smith",
     "picture" => "http://localhost:3000/uploads/user/avatar/1/index.jpg",
     "preferred_username" => "john_smith",

--- a/test/assent/strategies/google_test.exs
+++ b/test/assent/strategies/google_test.exs
@@ -17,6 +17,7 @@ defmodule Assent.Strategy.GoogleTest do
    }
   @user  %{
     "email" => "aaron.parecki@okta.com",
+    "email_verified" => true,
     "family_name" => "Parecki",
     "given_name" => "Aaron",
     "google_hd" => "okta.com",

--- a/test/assent/strategies/twitter_test.exs
+++ b/test/assent/strategies/twitter_test.exs
@@ -3,7 +3,7 @@ defmodule Assent.Strategy.TwitterTest do
 
   alias Assent.Strategy.Twitter
 
-  # From ttps://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
+  # From https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
   @user_response %{
     "id" => 2_244_994_945,
     "id_str" => "2244994945",
@@ -117,6 +117,7 @@ defmodule Assent.Strategy.TwitterTest do
   }
   @user %{
     "name" => "Twitter Dev",
+    "email_verified" => true,
     "picture" => "https://pbs.twimg.com/profile_images/880136122604507136/xHrnqf1T_normal.jpg",
     "preferred_username" => "TwitterDev",
     "profile" => "https://twitter.com/TwitterDev",


### PR DESCRIPTION
Resolves #32 

This also prompted me to go through all strategies to ensure there is proper handling or information about `email_verified`.