### PR TITLE
Update to use the instagram graph API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.9 (TBA)
+
+* `Assent.Strategy.Instagram` now uses the Instagram Graph API
+
 ## v0.1.8 (2020-02-15)
 
 * `Assent.Strategy.Github` now provides `email_verified` value

--- a/lib/assent/strategies/instagram.ex
+++ b/lib/assent/strategies/instagram.ex
@@ -19,8 +19,11 @@ defmodule Assent.Strategy.Instagram do
   @impl true
   def default_config(_config) do
     [
-      site: "https://api.instagram.com",
-      authorization_params: [scope: "basic"],
+      site: "https://graph.instagram.com",
+      authorize_url: "https://api.instagram.com/oauth/authorize",
+      token_url: "https://api.instagram.com/oauth/access_token",
+      user_url: "/me",
+      authorization_params: [scope: "user_profile"],
       auth_method: :client_secret_post
     ]
   end
@@ -29,14 +32,7 @@ defmodule Assent.Strategy.Instagram do
   def normalize(_config, user) do
     {:ok, %{
       "sub"                => user["id"],
-      "name"               => user["full_name"],
-      "preferred_username" => user["username"],
-      "picture"            => user["profile_picture"]
+      "preferred_username" => user["username"]
     }}
-  end
-
-  @impl true
-  def get_user(_config, token) do
-    {:ok, token["user"]}
   end
 end


### PR DESCRIPTION
The Instagram API has changed per https://developers.facebook.com/blog/post/2020/03/10/final-reminder-Instagram-legacy-api-platform-disabled-mar-31/

This resolves it.