### PR TITLE
Update instagram strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Now requires Mint 1.0.0 or higher.
 
+* `Assent.Strategy.Instagram` now accepts `:user_url_request_fields` config option and passes `fields` params to the `/me` point
+
 ## v0.1.9 (2020-04-23)
 
 Now requires Elixir 1.7 or higher.

--- a/lib/assent/strategies/instagram.ex
+++ b/lib/assent/strategies/instagram.ex
@@ -16,6 +16,8 @@ defmodule Assent.Strategy.Instagram do
   """
   use Assent.Strategy.OAuth2.Base
 
+  alias Assent.{Config, Strategy.OAuth2}
+
   @impl true
   def default_config(_config) do
     [
@@ -23,9 +25,22 @@ defmodule Assent.Strategy.Instagram do
       authorize_url: "https://api.instagram.com/oauth/authorize",
       token_url: "https://api.instagram.com/oauth/access_token",
       user_url: "/me",
+      user_url_request_fields: "id,username",
       authorization_params: [scope: "user_profile"],
       auth_method: :client_secret_post
     ]
+  end
+
+  @impl true
+  def get_user(config, access_token) do
+    with {:ok, fields} <- Config.fetch(config, :user_url_request_fields) do
+      params = [
+        fields: fields,
+        access_token: access_token["access_token"]
+      ]
+
+      OAuth2.get_user(config, access_token, params)
+    end
   end
 
   @impl true

--- a/test/assent/strategies/instagram_test.exs
+++ b/test/assent/strategies/instagram_test.exs
@@ -29,7 +29,13 @@ defmodule Assent.Strategy.InstagramTest do
       expect_oauth2_access_token_request(bypass, [uri: "/oauth/access_token", params: %{access_token: "access_token", user: @user_response}], fn _conn, params ->
         assert params["client_secret"] == config[:client_secret]
       end)
-      expect_oauth2_user_request(bypass, @user_response, uri: "/me")
+
+      expect_oauth2_user_request(bypass, @user_response, [uri: "/me"], fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+
+        assert conn.params["access_token"] == "access_token"
+        assert conn.params["fields"] == "id,username"
+      end)
 
       assert {:ok, %{user: user}} = Instagram.callback(config, params)
       assert user == @user


### PR DESCRIPTION
This models the facebook strategy as it's graphing API and you have to explicitly define the fields to retrieve.