### PR TITLE
Capitalize token type to match OAuth 2.0 RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.12 (TBA)
+
+* `Assent.Strategy.OAuth2.authorization_headers/2` now capitalizes the token type in the authorization header
+
 ## v0.1.11 (2020-05-16)
 
 * `Assent.Strategy.OAuth2.callback/2` now requires `:session_params` to be set in the config

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -295,7 +295,7 @@ defmodule Assent.Strategy.OAuth2 do
 
   @spec authorization_headers(Config.t(), map()) :: [{binary(), binary()}]
   def authorization_headers(_config, token) do
-    access_token_type = Map.get(token, "token_type", "Bearer")
+    access_token_type = Map.get(token, "token_type", "Bearer") |> String.capitalize()
     access_token = token["access_token"]
 
     [{"authorization", "#{access_token_type} #{access_token}"}]

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -295,10 +295,13 @@ defmodule Assent.Strategy.OAuth2 do
 
   @spec authorization_headers(Config.t(), map()) :: [{binary(), binary()}]
   def authorization_headers(_config, token) do
-    access_token_type = Map.get(token, "token_type", "Bearer") |> String.capitalize()
-    access_token = token["access_token"]
-
-    [{"authorization", "#{access_token_type} #{access_token}"}]
+    token
+    |> Map.get("token_type", "Bearer")
+    |> String.capitalize()
+    |> case do
+      "Bearer" -> [{"authorization", "Bearer #{token["access_token"]}"}]
+      _any     -> []
+    end
   end
 
   defp process_user_response({:ok, %HTTPResponse{status: 200, body: user}}), do: {:ok, user}

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -308,4 +308,13 @@ defmodule Assent.Strategy.OAuth2Test do
       assert token == %{"access_token" => "access_token"}
     end
   end
+
+  test "authorization_headers/2" do
+    assert OAuth2.authorization_headers([], %{"access_token" => "token"}) == [{"authorization", "Bearer token"}]
+
+    for token_type <- ["bearer", "Bearer"],
+      do: assert OAuth2.authorization_headers([], %{"access_token" => "token", "token_type" => token_type}) == [{"authorization", "Bearer token"}]
+
+    assert OAuth2.authorization_headers([], %{"access_token" => "token", "token_type" => "Max"}) == []
+  end
 end

--- a/test/support/strategies/oauth2_test_case.ex
+++ b/test/support/strategies/oauth2_test_case.ex
@@ -39,7 +39,7 @@ defmodule Assent.Test.OAuth2TestCase do
 
   @spec expect_oauth2_user_request(Bypass.t(), map(), Keyword.t(), function() | nil) :: :ok
   def expect_oauth2_user_request(bypass, user_params, opts \\ [], assert_fn \\ nil) do
-    uri          = Keyword.get(opts, :uri, "/api/user")
+    uri = Keyword.get(opts, :uri, "/api/user")
 
     expect_oauth2_api_request(bypass, uri, user_params, opts, assert_fn)
   end


### PR DESCRIPTION
I ran into this issue while trying to use the OIDC strategy with the Twitch API. Twitch returns a token_type: `bearer`, but they will validate against it being the capitalized string `Bearer`. According to the [OAuth 2.0 RFC](https://tools.ietf.org/html/rfc6750#section-2.1) the Authorization header should contain a capitalized Bearer string. This change will make it so that it will always return a capitalized token type.

I was not sure where to add a test for this in the spec, but I am happy to add one if you can point me in the right direction.