### PR TITLE
Refactor OIDC get_user handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * `Assent.Strategy.OAuth2.authorization_headers/2` now capitalizes the token type in the authorization header
 * `Assent.Strategy.OIDC.callback/2` now calls the strategy `get_user/2` method before any ID token validation
-* `Assent.Strategy.OIDC.validate_id_token/2` is now a public method
+* `Assent.Strategy.OIDC.validate_id_token/2` added
+* `Assent.Strategy.OIDC.fetch_userinfo/2` added
+* `Assent.Strategy.OIDC` no longer fetches the userinfo by default instead using the claims in the ID Token
 
 ## v0.1.11 (2020-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.1.12 (TBA)
 
 * `Assent.Strategy.OAuth2.authorization_headers/2` now capitalizes the token type in the authorization header
+* `Assent.Strategy.OIDC.callback/2` now calls the strategy `get_user/2` method before any ID token validation
+* `Assent.Strategy.OIDC.validate_id_token/2` is now a public method
 
 ## v0.1.11 (2020-05-16)
 

--- a/lib/assent/strategies/apple.ex
+++ b/lib/assent/strategies/apple.ex
@@ -110,8 +110,4 @@ defmodule Assent.Strategy.Apple do
 
   @impl true
   def normalize(_config, user), do: {:ok, user}
-
-  @impl true
-  def get_user(_config, %{"id_token" => %{claims: claims}}),
-    do: {:ok, claims}
 end

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -34,7 +34,7 @@ defmodule Assent.Strategy.AzureAD do
   """
   use Assent.Strategy.OIDC.Base
 
-  alias Assent.Config
+  alias Assent.{Config, Strategy.OIDC}
 
   @impl true
   def default_config(config) do
@@ -51,6 +51,9 @@ defmodule Assent.Strategy.AzureAD do
   def normalize(_config, user), do: {:ok, user}
 
   @impl true
-  def get_user(_config, %{"id_token" => %{claims: claims}}),
-    do: {:ok, claims}
+  def get_user(config, token) do
+    with {:ok, %{claims: claims}} <- OIDC.validate_id_token(config, token["id_token"]) do
+      {:ok, claims}
+    end
+  end
 end

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -34,7 +34,7 @@ defmodule Assent.Strategy.AzureAD do
   """
   use Assent.Strategy.OIDC.Base
 
-  alias Assent.{Config, Strategy.OIDC}
+  alias Assent.Config
 
   @impl true
   def default_config(config) do
@@ -49,11 +49,4 @@ defmodule Assent.Strategy.AzureAD do
 
   @impl true
   def normalize(_config, user), do: {:ok, user}
-
-  @impl true
-  def get_user(config, token) do
-    with {:ok, %{claims: claims}} <- OIDC.validate_id_token(config, token["id_token"]) do
-      {:ok, claims}
-    end
-  end
 end

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -218,23 +218,25 @@ defmodule Assent.Strategy.OIDC do
   defp to_client_auth_method("private_key_jwt"), do: {:ok, :private_key_jwt}
   defp to_client_auth_method(method), do: {:error, "Invalid client authentication method: #{method}"}
 
-  @doc false
+  @doc """
+  Fetches user params and normalizes response.
+
+  The ID Token is validated, and the claims is returned as the user params.
+  Use `fetch_userinfo/2` to fetch the claims from the `userinfo` endpoint.
+  """
   @spec get_user(Config.t(), map()) :: {:ok, map()} | {:error, term()}
   def get_user(config, token) do
-    with {:ok, openid_config} <- Config.fetch(config, :openid_configuration),
-         {:ok, jwt}           <- validate_id_token(config, token["id_token"]) do
-      fetch_and_normalize_userinfo(openid_config, config, token, jwt.claims)
+    with {:ok, jwt} <- validate_id_token(config, token["id_token"]) do
+      Helpers.normalize_userinfo(jwt.claims)
     end
   end
 
   @spec validate_id_token(Config.t(), binary()) :: {:ok, map()} | {:error, term()}
-  def validate_id_token(config, token) do
+  def validate_id_token(config, id_token) do
     with {:ok, openid_config} <- Config.fetch(config, :openid_configuration),
-         {:ok, header}        <- peek_header(token, config),
          {:ok, client_id}     <- Config.fetch(config, :client_id),
          {:ok, issuer}        <- fetch_from_openid_config(openid_config, "issuer"),
-         {:ok, secret_or_key} <- fetch_secret(header, openid_config, config),
-         {:ok, jwt}           <- Helpers.verify_jwt(token, secret_or_key, config),
+         {:ok, jwt}           <- verify_jwt(id_token, openid_config, config),
          :ok                  <- validate_required_fields(jwt),
          :ok                  <- validate_issuer_identifer(jwt, issuer),
          :ok                  <- validate_audience(jwt, client_id),
@@ -244,6 +246,13 @@ defmodule Assent.Strategy.OIDC do
          :ok                  <- validate_issued_at(jwt, config),
          :ok                  <- validate_nonce(jwt, config) do
       {:ok, jwt}
+    end
+  end
+
+  defp verify_jwt(token, openid_config, config) do
+    with {:ok, header}        <- peek_header(token, config),
+         {:ok, secret_or_key} <- fetch_secret(header, openid_config, config) do
+      Helpers.verify_jwt(token, secret_or_key, config)
     end
   end
 
@@ -361,22 +370,44 @@ defmodule Assent.Strategy.OIDC do
     do: {:error, "`nonce` included in ID Token but doesn't exist in session params"}
   defp validate_for_nonce(_any, _jwt), do: :ok
 
-  defp fetch_and_normalize_userinfo(openid_config, config, token, claims) do
-    openid_config
-    |> fetch_from_openid_config("userinfo_endpoint")
-    |> case do
-      {:ok, user_url} -> fetch_from_userinfo_endpoint(config, token, user_url)
-      {:error, _any}  -> {:ok, claims}
+  @spec fetch_userinfo(Config.t(), map()) :: {:ok, map()} | {:error, term()}
+  def fetch_userinfo(config, token) do
+    with {:ok, openid_config} <- Config.fetch(config, :openid_configuration),
+         {:ok, userinfo_url}  <- fetch_from_openid_config(openid_config, "userinfo_endpoint"),
+         {:ok, claims}        <- fetch_from_userinfo_endpoint(config, openid_config, token, userinfo_url),
+         {:ok, id_token}      <- verify_jwt(token["id_token"], openid_config, config),
+         :ok                  <- validate_userinfo_sub(id_token.claims, claims) do
+      {:ok, claims}
     end
-    |> normalize()
   end
 
-  defp fetch_from_userinfo_endpoint(config, token, user_url) do
+  defp fetch_from_userinfo_endpoint(config, openid_config, token, userinfo_url) do
     config
-    |> Config.put(:user_url, user_url)
-    |> OAuth2.get_user(token)
+    |> OAuth2.get(token, userinfo_url)
+    |> process_userinfo_response(openid_config, config)
   end
 
-  defp normalize({:ok, user}), do: Helpers.normalize_userinfo(user)
-  defp normalize({:error, error}), do: {:error, error}
+  defp process_userinfo_response({:ok, %HTTPResponse{status: 200, body: body, headers: headers}}, openid_config, config) do
+    case List.keyfind(headers, "content-type", 0) do
+      {"content-type", "application/jwt" <> _rest} -> process_jwt(body, openid_config, config)
+      _any                                         -> {:ok, body}
+    end
+  end
+  defp process_userinfo_response({:error, %HTTPResponse{status: 401}}, _openid_config, _config), do: {:error, %RequestError{message: "Unauthorized token"}}
+  defp process_userinfo_response(any, _openid_config, _config), do: process_response(any)
+
+  defp process_jwt(body, openid_config, config) do
+    with {:ok, jwt} <- verify_jwt(body, openid_config, config),
+         :ok        <- validate_verified(jwt) do
+      {:ok, jwt.claims}
+    end
+  end
+
+  defp process_response({:ok, %HTTPResponse{} = response}), do: {:error, RequestError.unexpected(response)}
+  defp process_response({:error, %HTTPResponse{} = response}), do: {:error, RequestError.invalid(response)}
+  defp process_response({:error, error}), do: {:error, error}
+
+  defp validate_userinfo_sub(%{"sub" => sub}, %{"sub" => sub}), do: :ok
+  defp validate_userinfo_sub(%{"sub" => _sub_1}, %{"sub" => _sub_2}), do: {:error, "`sub` in userinfo response not the same as in ID Token"}
+  defp validate_userinfo_sub(%{"sub" => _sub}, _claims), do: {:error, "`sub` not in userinfo response"}
 end

--- a/test/assent/strategies/oidc_test.exs
+++ b/test/assent/strategies/oidc_test.exs
@@ -93,6 +93,14 @@ defmodule Assent.Strategy.OIDCTest do
       assert OIDC.callback(config, params) == {:error, "The ID Token is not a valid JWT"}
     end
 
+    for key <- ~w(iss sub aud exp iat) do
+      test "with missing required #{key} keys in id_token", %{config: config, callback_params: params, bypass: bypass} do
+        expect_oidc_access_token_request(bypass, id_token_claims: %{unquote(key) => nil})
+
+        assert OIDC.callback(config, params) == {:error, "Missing `#{unquote(key)}` in ID Token claims"}
+      end
+    end
+
     test "with invalid `issuer` in id_token", %{config: config, callback_params: params, bypass: bypass} do
       expect_oidc_access_token_request(bypass, id_token_claims: %{"iss" => "invalid"})
 

--- a/test/assent/strategies/oidc_test.exs
+++ b/test/assent/strategies/oidc_test.exs
@@ -1,7 +1,7 @@
 defmodule Assent.Strategy.OIDCTest do
   use Assent.Test.OIDCTestCase
 
-  alias Assent.Strategy.OIDC
+  alias Assent.{RequestError, Strategy.OIDC}
 
   describe "authorize_url/2" do
     test "generates url and state", %{config: config, bypass: bypass} do
@@ -88,15 +88,13 @@ defmodule Assent.Strategy.OIDCTest do
       """
 
     test "with client_secret_basic authentication method", %{config: config, callback_params: params, bypass: bypass} do
-      expect_oidc_access_token_request(bypass, [], fn conn, _params ->
+      expect_oidc_access_token_request(bypass, [id_token_claims: @user_claims], fn conn, _params ->
         assert [{"authorization", "Basic " <> token} | _rest] = conn.req_headers
         assert [client_id, client_secret] = String.split(Base.url_decode64!(token, padding: false), ":")
 
         assert client_id == config[:client_id]
         assert client_secret == config[:client_secret]
       end)
-
-      expect_oauth2_user_request(bypass, @user_claims)
 
       assert {:ok, %{user: user, token: token}} = OIDC.callback(config, params)
       assert user == @user
@@ -116,7 +114,7 @@ defmodule Assent.Strategy.OIDCTest do
         |> Keyword.put(:private_key, @private_rsa_key)
         |> Keyword.put(:private_key_id, "key_id")
 
-      expect_oidc_access_token_request(bypass, [], fn _conn, params ->
+      expect_oidc_access_token_request(bypass, [id_token_claims: @user_claims], fn _conn, params ->
         assert {:ok, jwt} = Assent.JWTAdapter.AssentJWT.verify(params["client_assertion"], @public_rsa_key, json_library: Jason)
         assert jwt.header["alg"] == "RS256"
         assert jwt.header["typ"] == "JWT"
@@ -126,8 +124,6 @@ defmodule Assent.Strategy.OIDCTest do
         assert jwt.claims["aud"] == "http://localhost:#{bypass.port}"
         assert jwt.claims["exp"] > DateTime.to_unix(DateTime.utc_now())
       end)
-
-      expect_oauth2_user_request(bypass, @user_claims)
 
       assert {:ok, %{user: user, token: token}} = OIDC.callback(config, params)
       assert user == @user
@@ -228,8 +224,6 @@ defmodule Assent.Strategy.OIDCTest do
 
       expect_oidc_access_token_request(bypass, id_token_claims: %{"nonce" => "n-0S6_WzA2Mj"})
 
-      expect_oauth2_user_request(bypass, @user_claims)
-
       assert {:ok, _} = OIDC.callback(config, params)
     end
   end
@@ -253,7 +247,7 @@ defmodule Assent.Strategy.OIDCTest do
       expect_oidc_access_token_request(bypass, uri: "/dynamic/token/path")
 
       assert {:ok, %{user: user}} = OIDC.callback(config, params)
-      assert user == %{"sub" => "248289761001"}
+      assert user == %{"sub" => "1"}
     end
 
     test "with missing `token_endpoint` configuration options", %{config: config, openid_config: openid_config, callback_params: params, bypass: bypass} do
@@ -337,7 +331,7 @@ defmodule Assent.Strategy.OIDCTest do
       expect_oidc_jwks_uri_request(bypass, count: 1)
 
       assert {:ok, %{user: user, token: token}} = OIDC.callback(config, params)
-      assert user == %{"sub" => "248289761001"}
+      assert user == %{"sub" => "1"}
       assert %{"access_token" => "access_token", "id_token" => _id_token} = token
     end
 
@@ -364,20 +358,71 @@ defmodule Assent.Strategy.OIDCTest do
       expect_oidc_jwks_uri_request(bypass)
 
       assert {:ok, %{user: user, token: token}} = OIDC.callback(config, params)
-      assert user == %{"sub" => "248289761001"}
+      assert user == %{"sub" => "1"}
       assert %{"access_token" => "access_token", "id_token" => _id_token} = token
     end
+  end
 
-    test "with `userinfo_endpoint` in configuration options", %{config: config, openid_config: openid_config, callback_params: params, bypass: bypass} do
-      expect_openid_config_request(bypass, Map.put(openid_config, "userinfo_endpoint", "/dynamic/userinfo/path"))
+  describe "fetch_userinfo/2" do
+    setup %{bypass: bypass} do
+      token = %{"access_token" => "access_token", "id_token" => gen_id_token(bypass)}
 
-      expect_oidc_access_token_request(bypass, uri: "/dynamic/token/path")
+      {:ok, token: token}
+    end
 
-      expect_oauth2_user_request(bypass, @user_claims, uri: "/dynamic/userinfo/path")
+    test "with missing `userinfo_endpoint` in configuration options", %{config: config, token: token} do
+      openid_configuration = Map.delete(config[:openid_configuration], "userinfo_endpoint")
+      config               = Keyword.put(config, :openid_configuration, openid_configuration)
 
-      assert {:ok, %{user: user, token: token}} = OIDC.callback(config, params)
-      assert user == @user
-      assert %{"access_token" => "access_token", "id_token" => _id_token} = token
+      assert OIDC.fetch_userinfo(config, token) == {:error, "`userinfo_endpoint` not found in OpenID configuration"}
+    end
+
+    test "with unreachable `userinfo_endpoint`", %{config: config, token: token} do
+      openid_configuration = Map.put(config[:openid_configuration], "userinfo_endpoint", "http://localhost:8888/userinfo")
+      config               = Keyword.put(config, :openid_configuration, openid_configuration)
+
+      assert {:error, %RequestError{} = error} = OIDC.fetch_userinfo(config, token)
+      assert error.error == :unreachable
+      assert error.message =~ "Server was unreachable with Assent.HTTPAdapter.Httpc."
+      assert error.message =~ "{:failed_connect"
+      assert error.message =~ "URL: http://localhost:8888/userinfo"
+    end
+
+    test "with unauthorized `userinfo_endpoint`", %{config: config, token: token, bypass: bypass} do
+      expect_oidc_userinfo_request(bypass, %{"error" => "Unauthorized"}, status_code: 401)
+
+      assert {:error, %RequestError{} = error} = OIDC.fetch_userinfo(config, token)
+      assert error.message == "Unauthorized token"
+      refute error.error
+    end
+
+    test "with missing `sub` in userinfo claims", %{config: config, token: token, bypass: bypass} do
+      expect_oidc_userinfo_request(bypass, Map.delete(@user_claims, :sub))
+
+      assert OIDC.fetch_userinfo(config, token) == {:error, "`sub` not in userinfo response"}
+    end
+
+    test "with different `sub` in userinfo claims", %{config: config, token: token, bypass: bypass} do
+      expect_oidc_userinfo_request(bypass, Map.put(@user_claims, :sub, "2"))
+
+      assert OIDC.fetch_userinfo(config, token) == {:error, "`sub` in userinfo response not the same as in ID Token"}
+    end
+
+    test "with invalid jwt signature", %{config: config, token: token, bypass: bypass} do
+      [header, payload, _signature] =
+        bypass
+        |> gen_id_token()
+        |> String.split(".")
+
+      expect_oidc_userinfo_request(bypass, "#{header}.#{payload}.invalid")
+
+      assert OIDC.fetch_userinfo(config, token) == {:error, "Invalid JWT signature for ID Token"}
+    end
+
+    test "with valid jwt", %{config: config, token: token, bypass: bypass} do
+      expect_oidc_userinfo_request(bypass, gen_id_token(bypass))
+
+      assert {:ok, %{"sub" => "1"}} = OIDC.fetch_userinfo(config, token)
     end
   end
 end

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -48,7 +48,7 @@ defmodule Assent.Test.OIDCTestCase do
   @client_id "id"
   @client_secret "secret"
   @claims %{
-    "sub" => "248289761001",
+    "sub" => "1",
     "aud" => @client_id,
     "exp" => 1_311_281_970,
     "iat" => 1_311_280_970
@@ -64,7 +64,7 @@ defmodule Assent.Test.OIDCTestCase do
         "id_token_signed_response_alg" => ["HS256"],
         "authorization_endpoint" => "http://localhost:#{bypass.port}/oauth/authorize",
         "token_endpoint" => "http://localhost:#{bypass.port}/oauth/token",
-        "userinfo_endpoint" => "http://localhost:#{bypass.port}/api/user"
+        "userinfo_endpoint" => "http://localhost:#{bypass.port}/userinfo"
       },
       client_secret: @client_secret,
       site: "http://localhost:#{bypass.port}",
@@ -110,6 +110,27 @@ defmodule Assent.Test.OIDCTestCase do
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.send_resp(200, Jason.encode!(%{"keys" => keys}))
+    end)
+  end
+
+  @spec expect_oidc_userinfo_request(Bypass.t(), map() | binary(), Keyword.t()) :: :ok
+  def expect_oidc_userinfo_request(bypass, claims_or_jwt, opts \\ [])
+  def expect_oidc_userinfo_request(bypass, claims, opts) when is_map(claims) do
+    opts = Keyword.put_new(opts, :uri, "/userinfo")
+
+    OAuth2TestCase.expect_oauth2_user_request(bypass, claims, opts)
+  end
+  def expect_oidc_userinfo_request(bypass, jwt, opts) when is_binary(jwt) do
+    uri          = Keyword.get(opts, :uri, "/userinfo")
+    access_token = Keyword.get(opts, :access_token, "access_token")
+    status_code  = Keyword.get(opts, :status_code, 200)
+
+    Bypass.expect_once(bypass, "GET", uri, fn conn ->
+      assert {"authorization", "Bearer #{access_token}"} in conn.req_headers
+
+      conn
+      |> Conn.put_resp_content_type("application/jwt")
+      |> Conn.send_resp(status_code, jwt)
     end)
   end
 

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -132,6 +132,8 @@ defmodule Assent.Test.OIDCTestCase do
       |> Map.put("iat", :os.system_time(:second))
       |> Map.merge(Keyword.get(opts, :id_token_claims, %{}))
 
+    claims = Map.drop(claims, Enum.filter(Map.keys(claims), &is_nil(claims[&1])))
+
     [jwk, jws] = signing_alg(opts)
     jwt        = JOSE.JWT.sign(jwk, add_kid(jws, opts), claims)
     {_, token} = JOSE.JWS.compact(jwt)


### PR DESCRIPTION
The OIDC strategy now calls the strategy `get_user/2` directly rather than the previous nested call. This means that any custom implementation of `get_user/2` for a OIDC strategy must use the `validate_id_token/2` method to conform to OIDC specs.

The default `get_user/2` behavior is to use the claims in the ID token rather than, as previously, fetching from the userinfo endpoint. The two strategies using OIDC uses the claims already so this simplifies things. If a strategy needs to call the userinfo endpoint, `fetch_userinfo/2` has been added that conforms with validation requirements from the OIDC specs.