### PR TITLE
Add refresh token logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.1.14 (TBA)
 
+* `Assent.Strategy.OAuth2.get_access_token/3` added
 * `Assent.Strategy.OAuth2.refresh_access_token/3` added
 
 ## v0.1.13 (2020-07-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.14 (TBA)
+
+* `Assent.Strategy.OAuth2.refresh_access_token/3` added
+
 ## v0.1.13 (2020-07-14)
 
 * `Assent.Strategy.DigitalOcean` added

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -106,7 +106,9 @@ defmodule Assent.Strategy.OAuth2 do
   end
 
   @doc """
-  Callback phase for generating access token and fetch user data.
+  Callback phase for generating access token with authorization code and fetch
+  user data. Returns a map with access token in `:token` and user data in
+  `:user`.
 
   ## Configuration
 
@@ -268,15 +270,18 @@ defmodule Assent.Strategy.OAuth2 do
     end
   end
 
+  @doc """
+  Refreshes the access token.
+  """
   @spec refresh_access_token(Config.t(), map(), Keyword.get()) :: {:ok, map()} | {:error, term()}
   def refresh_access_token(config, token, params \\ []) do
     access_token_request(config, "refresh_token", params ++ [refresh_token: token["refresh_token"]])
   end
 
   @doc """
-  Makes a HTTP get request to the API.
+  Performs a HTTP GET request to the API using the access token.
 
-  JSON responses will be decoded to maps.
+  Uses `authorization_headers/2` for headers.
   """
   @spec get(Config.t(), map(), binary(), map() | Keyword.t()) :: {:ok, map()} | {:error, term()}
   def get(config, token, url, params \\ []) do
@@ -290,6 +295,11 @@ defmodule Assent.Strategy.OAuth2 do
     end
   end
 
+  @doc """
+  Fetch user data with the access token.
+
+  Uses `get/4` to fetch the user data.
+  """
   @spec get_user(Config.t(), map(), map() | Keyword.t()) :: {:ok, map()} | {:error, term()}
   def get_user(config, token, params \\ []) do
     case Config.fetch(config, :user_url) do
@@ -303,6 +313,11 @@ defmodule Assent.Strategy.OAuth2 do
     end
   end
 
+  @doc """
+  Authorization header used for the access token.
+
+  Defaults to `Bearer`.
+  """
   @spec authorization_headers(Config.t(), map()) :: [{binary(), binary()}]
   def authorization_headers(_config, token) do
     token

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -156,7 +156,7 @@ defmodule Assent.Strategy.OAuth2 do
   defp maybe_check_state(_session_params, _params), do: :ok
 
   defp authentication_params(nil, config) do
-    with {:ok, client_id}     <- Config.fetch(config, :client_id) do
+    with {:ok, client_id} <- Config.fetch(config, :client_id) do
 
       headers = []
       body    = [client_id: client_id]
@@ -242,7 +242,7 @@ defmodule Assent.Strategy.OAuth2 do
     with {:ok, site}                    <- Config.fetch(config, :site),
          {:ok, auth_headers, auth_body} <- authentication_params(auth_method, config) do
       headers = [{"content-type", "application/x-www-form-urlencoded"}] ++ auth_headers
-      params  = Keyword.merge(params, auth_body ++ [grant_type: grant_type])
+      params  = Keyword.merge(params, Keyword.put(auth_body, :grant_type, grant_type))
       url     = Helpers.to_url(site, token_url)
       body    = URI.encode_query(params)
 
@@ -275,7 +275,7 @@ defmodule Assent.Strategy.OAuth2 do
   @spec refresh_access_token(Config.t(), map(), Keyword.get()) :: {:ok, map()} | {:error, term()}
   def refresh_access_token(config, token, params \\ []) do
     with {:ok, refresh_token} <- fetch_from_token(token, "refresh_token") do
-      get_access_token(config, "refresh_token", params ++ [refresh_token: refresh_token])
+      get_access_token(config, "refresh_token", Keyword.put(params, :refresh_token, refresh_token))
     end
   end
 


### PR DESCRIPTION
Was prompted by this question on elixir slack by `mohamedAqib`:

> is there anyway for me to get an automated job to refresh the token of users based on their provider it connects to if i use `pow_assent`?
> I understand that part (auth with own system). What i meant was how to automate the access token from provider. Eg if the user sign in with Microsoft graph, the token access only for 1 hour. Is there any built in pow method to get a new access token from Microsoft graph (using the given refresh token)

I realized that there isn't really an easy way to do this with Assent or PowAssent, so this adds a `Assent.Strategy.OAuth2.refresh_access_token/3` method that can be called to update the access token.

Examples:

```elixir
Assent.Strategy.OAuth2.refresh_access_token(strategy_config, %{"refresh_token" => refresh_token})

Assent.Strategy.OAuth2.refresh_access_token(strategy_config, %{"refresh_token" => refresh_token}, scope: "read")
```