### PR TITLE
Handle name scope for Apple strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `Assent.Strategy.OAuth2.get_access_token/3` added
 * `Assent.Strategy.OAuth2.refresh_access_token/3` added
 * `Assent.Strategy.OAuth2.authorization_headers/2` is no long a public function
+* `Assent.Strategy.Apple` updated to handle `name` scope
 
 ## v0.1.13 (2020-07-14)
 

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -95,8 +95,12 @@ defmodule Assent.Test.OIDCTestCase do
 
   @spec expect_oidc_access_token_request(Bypass.t(), Keyword.t(), function() | nil) :: :ok
   def expect_oidc_access_token_request(bypass, opts \\ [], assert_fn \\ nil) do
-    token = Keyword.get(opts, :id_token) || gen_id_token(bypass, opts)
-    opts  = Keyword.put(opts, :params, %{access_token: "access_token", id_token: token})
+    params =
+      opts
+      |> Keyword.get(:params, %{access_token: "access_token"})
+      |> Map.put_new(:id_token, Keyword.get(opts, :id_token) || gen_id_token(bypass, opts))
+
+    opts = Keyword.put(opts, :params, params)
 
     OAuth2TestCase.expect_oauth2_access_token_request(bypass, opts, assert_fn)
   end


### PR DESCRIPTION
Apple doesn't conform to OIDC so this PR conforms the response so it's easier to work with. It adds name scope handling.

Helps with https://github.com/pow-auth/assent/issues/51#issuecomment-675003156