### PR TITLE
Add LINE Login OpenID Connect Strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `Assent.Strategy.OIDC.validate_id_token/2` has a bug fixed where `alg` was not validated correctly
 * `Assent.Strategy.OIDC` now has an `:id_token_signed_response_alg` configuration option
+* `Assent.Strategy.LINE` added
 
 ## v0.1.14 (2020-10-11)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Multi-provider authentication framework.
   * Slack - `Assent.Strategy.Slack`
   * Twitter - `Assent.Strategy.Twitter`
   * VK - `Assent.Strategy.VK`
+  * LINE Login - `Assent.Strategy.LINE`
 
 ## Installation
 

--- a/lib/assent/strategies/line.ex
+++ b/lib/assent/strategies/line.ex
@@ -1,0 +1,30 @@
+defmodule Assent.Strategy.LINE do
+  @moduledoc """
+  LINE Login OpenID Connect Strategy.
+
+  See `Assent.Strategy.OIDC` for more.
+  """
+
+  use Assent.Strategy.OIDC.Base
+
+  @impl true
+  def default_config(_config) do
+    [
+      site: "https://access.line.me",
+      authorization_params: [scope: "email profile", response_type: "code"],
+      openid_configuration: %{
+        "id_token_signed_response_alg" => ["HS256"],
+        "issuer" => "https://access.line.me",
+        "authorization_endpoint" => "https://access.line.me/oauth2/v2.1/authorize",
+        "token_endpoint" => "https://api.line.me/oauth2/v2.1/token",
+        "jwks_uri" => "https://api.line.me/oauth2/v2.1/certs",
+        "response_types_supported" => ["code"],
+        "subject_types_supported" => ["pairwise"],
+        "id_token_signing_alg_values_supported" => ["ES256"]
+      }
+    ]
+  end
+
+  @impl true
+  def normalize(_config, user), do: {:ok, user}
+end

--- a/lib/assent/strategies/line.ex
+++ b/lib/assent/strategies/line.ex
@@ -12,16 +12,7 @@ defmodule Assent.Strategy.LINE do
     [
       site: "https://access.line.me",
       authorization_params: [scope: "email profile", response_type: "code"],
-      openid_configuration: %{
-        "id_token_signed_response_alg" => ["HS256"],
-        "issuer" => "https://access.line.me",
-        "authorization_endpoint" => "https://access.line.me/oauth2/v2.1/authorize",
-        "token_endpoint" => "https://api.line.me/oauth2/v2.1/token",
-        "jwks_uri" => "https://api.line.me/oauth2/v2.1/certs",
-        "response_types_supported" => ["code"],
-        "subject_types_supported" => ["pairwise"],
-        "id_token_signing_alg_values_supported" => ["ES256"]
-      }
+      id_token_signed_response_alg: "HS256"
     ]
   end
 

--- a/test/assent/strategies/line_test.exs
+++ b/test/assent/strategies/line_test.exs
@@ -3,25 +3,22 @@ defmodule Assent.Strategy.LINETest do
 
   alias Assent.Strategy.LINE
 
-  @id_token elem(
-              Assent.Strategy.sign_jwt(
-                %{
-                  "iss" => "https://access.line.me",
-                  "sub" => "U1234567890abcdef1234567890abcdef ",
-                  "aud" => "1234567890",
-                  "exp" => :os.system_time(:second) + 60,
-                  "iat" => :os.system_time(:second),
-                  "nonce" => "0987654asdf",
-                  "amr" => ["pwd"],
-                  "name" => "Taro Line",
-                  "picture" => "https://sample_line.me/aBcdefg123456"
-                },
-                "HS256",
-                "secret",
-                []
-              ),
-              1
-            )
+  # From https://developers.line.biz/en/docs/line-login/integrate-line-login/#verify-id-token
+  @id_token elem(Assent.Strategy.sign_jwt(
+    %{
+      "iss" => "https://access.line.me",
+      "sub" => "U1234567890abcdef1234567890abcdef ",
+      "aud" => "1234567890",
+      "exp" => :os.system_time(:second) + 60,
+      "iat" => :os.system_time(:second),
+      "nonce" => "0987654asdf",
+      "amr" => ["pwd"],
+      "name" => "Taro Line",
+      "picture" => "https://sample_line.me/aBcdefg123456"
+    },
+    "HS256",
+    "secret",
+    []), 1)
   @user %{
     "name" => "Taro Line",
     "picture" => "https://sample_line.me/aBcdefg123456",
@@ -35,17 +32,9 @@ defmodule Assent.Strategy.LINETest do
   end
 
   test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
-    openid_config =
-      Map.merge(config[:openid_configuration], %{"issuer" => "https://access.line.me"})
-
+    openid_config  = Map.merge(config[:openid_configuration], %{"issuer" => "https://access.line.me"})
     session_params = Map.put(config[:session_params], :nonce, "0987654asdf")
-
-    config =
-      Keyword.merge(config,
-        openid_configuration: openid_config,
-        client_id: "1234567890",
-        session_params: session_params
-      )
+    config         = Keyword.merge(config, openid_configuration: openid_config, client_id: "1234567890", session_params: session_params)
 
     expect_oidc_access_token_request(bypass, id_token: @id_token)
 

--- a/test/assent/strategies/line_test.exs
+++ b/test/assent/strategies/line_test.exs
@@ -1,0 +1,55 @@
+defmodule Assent.Strategy.LINETest do
+  use Assent.Test.OIDCTestCase
+
+  alias Assent.Strategy.LINE
+
+  @id_token elem(
+              Assent.Strategy.sign_jwt(
+                %{
+                  "iss" => "https://access.line.me",
+                  "sub" => "U1234567890abcdef1234567890abcdef ",
+                  "aud" => "1234567890",
+                  "exp" => :os.system_time(:second) + 60,
+                  "iat" => :os.system_time(:second),
+                  "nonce" => "0987654asdf",
+                  "amr" => ["pwd"],
+                  "name" => "Taro Line",
+                  "picture" => "https://sample_line.me/aBcdefg123456"
+                },
+                "HS256",
+                "secret",
+                []
+              ),
+              1
+            )
+  @user %{
+    "name" => "Taro Line",
+    "picture" => "https://sample_line.me/aBcdefg123456",
+    "sub" => "U1234567890abcdef1234567890abcdef "
+  }
+
+  test "authorize_url/2", %{config: config} do
+    assert {:ok, %{url: url}} = LINE.authorize_url(config)
+    assert url =~ "scope=openid+email+profile"
+    assert url =~ "response_type=code"
+  end
+
+  test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
+    openid_config =
+      Map.merge(config[:openid_configuration], %{"issuer" => "https://access.line.me"})
+
+    session_params = Map.put(config[:session_params], :nonce, "0987654asdf")
+
+    config =
+      Keyword.merge(config,
+        openid_configuration: openid_config,
+        client_id: "1234567890",
+        session_params: session_params
+      )
+
+    expect_oidc_access_token_request(bypass, id_token: @id_token)
+
+    assert {:ok, %{user: user}} = LINE.callback(config, params)
+    assert user == @user
+  end
+end


### PR DESCRIPTION
Add default LINE Login OpenID Connect configuration. The openid configuration
dump from /.well-known/openid-configuration plus `id_token_signed_response_alg`
to make it work on ID Token with alg HS256.

Closes #57