### PR TITLE
Refactor handling of OIDC and fix issue with alg validation

### DIFF
--- a/lib/assent/strategies/apple.ex
+++ b/lib/assent/strategies/apple.ex
@@ -57,7 +57,6 @@ defmodule Assent.Strategy.Apple do
       site: site,
       openid_configuration: %{
         "issuer" => "https://appleid.apple.com",
-        "id_token_signed_response_alg" => ["RS256"],
         "authorization_endpoint" => site <> "/auth/authorize",
         "token_endpoint" => site <> "/auth/token",
         "jwks_uri" => site <> "/auth/keys",

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -44,6 +44,7 @@ defmodule Assent.Strategy.AzureAD do
       site: "https://login.microsoftonline.com/#{tenant_id}/v2.0",
       authorization_params: [scope: "email profile", response_mode: "form_post"],
       client_auth_method: :client_secret_post,
+      id_token_signed_response_alg: "HS256"
     ]
   end
 


### PR DESCRIPTION
With #58 it was evident that something was wrong in the validation step for `alg`. This resolves it so now the configuration option has `:id_token_signed_response_alg` to specific for `alg` should be used.

I've also made a bunch of refactor for the tests to make it easier to read and understand.