### PR TITLE
Rename get_user functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.1.16 (TBA)
+
+**Warning:** This release has breaking changes.
+
+All `get_user/2` functions has been renamed to `fetch_user/2` as they return `{:ok, res}`/`{:error, res}` tuples.
+
+* `Assent.OAuth.get/4` removed in favor of `Assent.OAuth.request/6`
+* `Assent.OAuth2.get_access_token/3` renamed to `Assent.OAuth2.grant_access_token/3`
+* `Assent.OAuth2.get/4` removed in favor of `Assent.OAuth2.request/6`
+
 ## v0.1.15 (2020-10-18)
 
 * `Assent.Strategy.OIDC.validate_id_token/2` has a bug fixed where `alg` was not validated correctly

--- a/lib/assent/strategies/apple.ex
+++ b/lib/assent/strategies/apple.ex
@@ -112,8 +112,8 @@ defmodule Assent.Strategy.Apple do
   end
 
   @impl true
-  def get_user(config, token) do
-    case OIDC.get_user(config, token) do
+  def fetch_user(config, token) do
+    case OIDC.fetch_user(config, token) do
       {:ok, user}     -> {:ok, merge_with_user_info(user, token)}
       {:error, error} -> {:error, error}
     end

--- a/lib/assent/strategies/facebook.ex
+++ b/lib/assent/strategies/facebook.ex
@@ -104,7 +104,7 @@ defmodule Assent.Strategy.Facebook do
   end
 
   @impl true
-  def get_user(config, access_token) do
+  def fetch_user(config, access_token) do
     with {:ok, fields} <- Config.fetch(config, :user_url_request_fields),
          {:ok, client_secret} <- Config.fetch(config, :client_secret) do
       params = [
@@ -113,7 +113,7 @@ defmodule Assent.Strategy.Facebook do
         access_token: access_token["access_token"]
       ]
 
-      OAuth2.get_user(config, access_token, params)
+      OAuth2.fetch_user(config, access_token, params)
     end
   end
 

--- a/lib/assent/strategies/instagram.ex
+++ b/lib/assent/strategies/instagram.ex
@@ -32,14 +32,14 @@ defmodule Assent.Strategy.Instagram do
   end
 
   @impl true
-  def get_user(config, access_token) do
+  def fetch_user(config, access_token) do
     with {:ok, fields} <- Config.fetch(config, :user_url_request_fields) do
       params = [
         fields: fields,
         access_token: access_token["access_token"]
       ]
 
-      OAuth2.get_user(config, access_token, params)
+      OAuth2.fetch_user(config, access_token, params)
     end
   end
 

--- a/lib/assent/strategies/oauth/base.ex
+++ b/lib/assent/strategies/oauth/base.ex
@@ -41,7 +41,7 @@ defmodule Assent.Strategy.OAuth.Base do
 
   @callback default_config(Keyword.t()) :: Keyword.t()
   @callback normalize(Keyword.t(), map()) :: {:ok, map()} | {:ok, map(), map()} | {:error, term()}
-  @callback get_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
+  @callback fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
 
   @doc false
   defmacro __using__(_opts) do
@@ -58,7 +58,7 @@ defmodule Assent.Strategy.OAuth.Base do
       def callback(config, params), do: unquote(__MODULE__).callback(config, params, __MODULE__)
 
       @impl unquote(__MODULE__)
-      def get_user(config, token), do: OAuth.get_user(config, token)
+      def fetch_user(config, token), do: OAuth.fetch_user(config, token)
 
       defoverridable unquote(__MODULE__)
     end

--- a/lib/assent/strategies/oauth2/base.ex
+++ b/lib/assent/strategies/oauth2/base.ex
@@ -36,7 +36,7 @@ defmodule Assent.Strategy.OAuth2.Base do
 
   @callback default_config(Keyword.t()) :: Keyword.t()
   @callback normalize(Keyword.t(), map()) :: {:ok, map()} | {:ok, map(), map()} | {:error, term()}
-  @callback get_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
+  @callback fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
 
   @doc false
   defmacro __using__(_opts) do
@@ -53,7 +53,7 @@ defmodule Assent.Strategy.OAuth2.Base do
       def callback(config, params), do: unquote(__MODULE__).callback(config, params, __MODULE__)
 
       @impl unquote(__MODULE__)
-      def get_user(config, token), do: OAuth2.get_user(config, token)
+      def fetch_user(config, token), do: OAuth2.fetch_user(config, token)
 
       defoverridable unquote(__MODULE__)
     end

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -226,8 +226,8 @@ defmodule Assent.Strategy.OIDC do
   The ID Token is validated, and the claims is returned as the user params.
   Use `fetch_userinfo/2` to fetch the claims from the `userinfo` endpoint.
   """
-  @spec get_user(Config.t(), map()) :: {:ok, map()} | {:error, term()}
-  def get_user(config, token) do
+  @spec fetch_user(Config.t(), map()) :: {:ok, map()} | {:error, term()}
+  def fetch_user(config, token) do
     with {:ok, jwt} <- validate_id_token(config, token["id_token"]) do
       Helpers.normalize_userinfo(jwt.claims)
     end
@@ -380,7 +380,7 @@ defmodule Assent.Strategy.OIDC do
 
   defp fetch_from_userinfo_endpoint(config, openid_config, token, userinfo_url) do
     config
-    |> OAuth2.get(token, userinfo_url)
+    |> OAuth2.request(token, :get, userinfo_url)
     |> process_userinfo_response(openid_config, config)
   end
 

--- a/lib/assent/strategies/oidc/base.ex
+++ b/lib/assent/strategies/oidc/base.ex
@@ -21,7 +21,7 @@ defmodule Assent.Strategy.OIDC.Base do
 
   @callback default_config(Keyword.t()) :: Keyword.t()
   @callback normalize(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
-  @callback get_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
+  @callback fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
 
   @doc false
   defmacro __using__(_opts) do
@@ -38,7 +38,7 @@ defmodule Assent.Strategy.OIDC.Base do
       def callback(config, params), do: unquote(__MODULE__).callback(config, params, __MODULE__)
 
       @impl unquote(__MODULE__)
-      def get_user(config, token), do: OIDC.get_user(config, token)
+      def fetch_user(config, token), do: OIDC.fetch_user(config, token)
 
       defoverridable unquote(__MODULE__)
       defoverridable Assent.Strategy

--- a/lib/assent/strategies/vk.ex
+++ b/lib/assent/strategies/vk.ex
@@ -54,14 +54,14 @@ defmodule Assent.Strategy.VK do
   end
 
   @impl true
-  def get_user(config, token) do
+  def fetch_user(config, token) do
     params =
       config
       |> Config.get(:user_url_params, [])
       |> Config.put(:access_token, token["access_token"])
 
     config
-    |> OAuth2.get_user(token, params)
+    |> OAuth2.fetch_user(token, params)
     |> handle_user_response(token)
   end
 

--- a/test/assent/strategies/twitter_test.exs
+++ b/test/assent/strategies/twitter_test.exs
@@ -135,7 +135,7 @@ defmodule Assent.Strategy.TwitterTest do
 
   test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
     expect_oauth_access_token_request(bypass)
-    expect_oauth_user_request(bypass, @user_response, uri: "/1.1/account/verify_credentials.json")
+    expect_oauth_user_request(bypass, @user_response, uri: "/1.1/account/verify_credentials.json", params: [include_entities: false, skip_status: true, include_email: true])
 
     assert {:ok, %{user: user}} = Twitter.callback(config, params)
     assert user == @user

--- a/test/support/strategies/oauth2_test_case.ex
+++ b/test/support/strategies/oauth2_test_case.ex
@@ -45,11 +45,11 @@ defmodule Assent.Test.OAuth2TestCase do
   end
 
   @spec expect_oauth2_api_request(Bypass.t(), binary(), map(), Keyword.t(), function() | nil) :: :ok
-  def expect_oauth2_api_request(bypass, uri, response, opts \\ [], assert_fn \\ nil) do
+  def expect_oauth2_api_request(bypass, uri, response, opts \\ [], assert_fn \\ nil, method \\ "GET") do
     access_token = Keyword.get(opts, :access_token, "access_token")
     status_code  = Keyword.get(opts, :status_code, 200)
 
-    Bypass.expect_once(bypass, "GET", uri, fn conn ->
+    Bypass.expect_once(bypass, method, uri, fn conn ->
       if assert_fn, do: assert_fn.(conn)
 
       assert_bearer_token_in_header(conn, access_token)


### PR DESCRIPTION
The naming wasn't super clear. In Elixir `get_` functions usually returns something or nil, while `fetch_` returns `{:ok, res}`/`{:error, res}` tuples. This is a breaking change, but I like the naming much better. Also renamed a few other functions, and should expand the tests a little.

Todo:

- [x] Add test for `Assent.Strategy.OAuth2.request/6` with POST
- [x] Add test for `Assent.Strategy.OAuth.request/6`