### PR TITLE
Skip the gen_state when use a custom state into the authorized_params config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.19 (TBA)
 
 * Updated docs to detail `:inets` compilation
+* `Assent.OAuth2.authorize_url/1` now returns the state, if defined, from `authorization_params`
 
 ## v0.1.18 (2020-11-08)
 

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -84,7 +84,7 @@ defmodule Assent.Strategy.OAuth2 do
     with {:ok, redirect_uri} <- Config.fetch(config, :redirect_uri),
          {:ok, site}         <- Config.fetch(config, :site),
          {:ok, client_id}    <- Config.fetch(config, :client_id) do
-      state         = gen_state()
+      state         = Config.get(config, :authorization_params, %{})[:state] || gen_state()
       params        = authorization_params(config, client_id, state, redirect_uri)
       authorize_url = Config.get(config, :authorize_url, "/oauth/authorize")
       url           = Helpers.to_url(site, authorize_url, params)

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -57,6 +57,16 @@ defmodule Assent.Strategy.OAuth2Test do
     assert url =~ "http://localhost:#{bypass.port}/oauth/authorize?client_id=#{@client_id}&redirect_uri=http%3A%2F%2Flocalhost%3A4000%2Fauth%2Fcallback&response_type=code&state=#{state}"
   end
 
+  test "authorize_url/2 with state in authorization_param", %{config: config} do
+    assert {:ok, %{session_params: %{state: state}}} =
+      config
+      |> Keyword.put(:client_id, @client_id)
+      |> Keyword.put(:authorization_params, state: "state_test_value")
+      |> OAuth2.authorize_url()
+
+    assert state == "state_test_value"
+  end
+
   describe "callback/2" do
     setup %{config: config} do
       config =
@@ -105,15 +115,6 @@ defmodule Assent.Strategy.OAuth2Test do
 
       assert {:error, %CallbackCSRFError{} = error} = OAuth2.callback(config, params)
       assert error.message == "CSRF detected with param key \"state\""
-    end
-
-    test "with custom state param", %{config: config, callback_params: params, bypass: bypass} do
-      config = Keyword.put(config, :authorization_params, %{state: "state_test_value"})
-
-      expect_oauth2_access_token_request(bypass, [])
-      expect_oauth2_user_request(bypass, %{})
-
-      assert {:ok, _any} = OAuth2.callback(config, params)
     end
 
     test "with state param without state in session_params", %{config: config, callback_params: params, bypass: bypass} do

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -107,6 +107,15 @@ defmodule Assent.Strategy.OAuth2Test do
       assert error.message == "CSRF detected with param key \"state\""
     end
 
+    test "with custom state param", %{config: config, callback_params: params, bypass: bypass} do
+      config = Keyword.put(config, :authorization_params, %{state: "state_test_value"})
+
+      expect_oauth2_access_token_request(bypass, [])
+      expect_oauth2_user_request(bypass, %{})
+
+      assert {:ok, _any} = OAuth2.callback(config, params)
+    end
+
     test "with state param without state in session_params", %{config: config, callback_params: params, bypass: bypass} do
       config = Keyword.put(config, :session_params, %{})
 


### PR DESCRIPTION
I'm using a custom state value on oauth2 to define some redirects into my application.

A better way to manage this, is creating a state param with base64 encoded content, to put whatever we want to send custom parameters to the oauth.

In my case, I created a oauth proxy to manage multiple applications using the same API credentials.