### PR TITLE
Remove mint handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix test
-      - run: MIX_ENV=test mix credo --ignore Credo.Check.Design.TagTODO
+      - run: MIX_ENV=test mix credo
   deploy:
     needs: test
     runs-on: ubuntu-latest

--- a/lib/assent/http_adapter/mint.ex
+++ b/lib/assent/http_adapter/mint.ex
@@ -32,19 +32,7 @@ defmodule Assent.HTTPAdapter.Mint do
   defp open_mint_conn("http", host, port, opts), do: open_mint_conn(:http, host, port, opts)
   defp open_mint_conn("https", host, port, opts), do: open_mint_conn(:https, host, port, opts)
   defp open_mint_conn(scheme, host, port, opts) when is_atom(scheme) do
-    # TODO: Remove when Mint has been fixed
-    # Mint <= 1.0.0 doesn't handle certificates for wildcard domain with SAN extension
-    hostname_match_check =
-      try do
-        case scheme do
-          :https -> [customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]]
-          _any   -> []
-        end
-      rescue
-        _e in UndefinedFunctionError -> []
-      end
-
-    transport_opts = Keyword.get(opts, :transport_opts, []) ++ hostname_match_check
+    transport_opts = Keyword.get(opts, :transport_opts, [])
     opts           = Keyword.put(opts, :transport_opts, transport_opts)
 
     Mint.HTTP.connect(scheme, host, port, opts)


### PR DESCRIPTION
With https://github.com/pow-auth/assent/pull/41 it's no longer necessary to explicitly handle wildcard domain with SAN extension