### PR TITLE
Preserve base64 encoding padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `Assent.Strategy.Stripe` added
 * `Assent.Strategy.to_url/3` now handles nested query params
+* `Assent.Strategy.OAuth2` no longer removes padding for base64 encoding authorization header
 
 ## v0.1.19 (2020-11-25)
 

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -176,7 +176,7 @@ defmodule Assent.Strategy.OAuth2 do
     with {:ok, client_id}     <- Config.fetch(config, :client_id),
          {:ok, client_secret} <- Config.fetch(config, :client_secret) do
 
-      auth    = Base.url_encode64("#{client_id}:#{client_secret}", padding: false)
+      auth    = Base.encode64("#{client_id}:#{client_secret}")
       headers = [{"authorization", "Basic #{auth}"}]
       body    = []
 

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -3,8 +3,8 @@ defmodule Assent.Strategy.OAuth2Test do
 
   alias Assent.{CallbackCSRFError, CallbackError, Config.MissingKeyError, JWTAdapter.AssentJWT, MissingParamError, RequestError, Strategy.OAuth2}
 
-  @client_id "id"
-  @client_secret "secret"
+  @client_id "s6BhdRkqt3"
+  @client_secret "7Fjfp0ZBr1KtDRbnfVdmIw"
   @private_key_id "key_id"
   @private_key """
     -----BEGIN RSA PRIVATE KEY-----
@@ -211,7 +211,7 @@ defmodule Assent.Strategy.OAuth2Test do
 
       expect_oauth2_access_token_request(bypass, [], fn conn, params ->
         assert [{"authorization", "Basic " <> token} | _rest] = conn.req_headers
-        assert Base.url_decode64(token, padding: false) == {:ok, "#{@client_id}:#{@client_secret}"}
+        assert Base.url_decode64(token) == {:ok, "#{@client_id}:#{@client_secret}"}
 
         assert params["grant_type"] == "authorization_code"
         assert params["code"] == "code_test_value"


### PR DESCRIPTION
This was handled incorrectly.