### PR TITLE
Handle callback errors with OAuth 1.0a strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.21 (TBA)
+
+* `Assent.Strategy.OAuth` now handles missing params in callback phase
+* `Assent.Strategy.Twitter` now handles access denied callback
+
 ## v0.1.20 (2020-12-10)
 
 * `Assent.Strategy.Stripe` added

--- a/lib/assent/strategies/oauth/base.ex
+++ b/lib/assent/strategies/oauth/base.ex
@@ -61,6 +61,7 @@ defmodule Assent.Strategy.OAuth.Base do
       def fetch_user(config, token), do: OAuth.fetch_user(config, token)
 
       defoverridable unquote(__MODULE__)
+      defoverridable Assent.Strategy
     end
   end
 

--- a/lib/assent/strategies/twitter.ex
+++ b/lib/assent/strategies/twitter.ex
@@ -16,6 +16,8 @@ defmodule Assent.Strategy.Twitter do
   """
   use Assent.Strategy.OAuth.Base
 
+  alias Assent.{CallbackError, Strategy.OAuth.Base}
+
   @impl true
   def default_config(_config) do
     [
@@ -25,6 +27,15 @@ defmodule Assent.Strategy.Twitter do
       access_token_url: "/oauth/access_token",
       user_url: "/1.1/account/verify_credentials.json?include_entities=false&skip_status=true&include_email=true",
     ]
+  end
+
+  @doc false
+  @impl true
+  def callback(config, params) do
+    case Map.has_key?(params, "denied") do
+      true  -> {:error, %CallbackError{message: "The user denied the authorization request"}}
+      false -> Base.callback(config, params, __MODULE__)
+    end
   end
 
   @impl true

--- a/test/assent/strategies/oauth_test.exs
+++ b/test/assent/strategies/oauth_test.exs
@@ -1,7 +1,7 @@
 defmodule Assent.Strategy.OAuthTest do
   use Assent.Test.OAuthTestCase
 
-  alias Assent.{Config.MissingKeyError, RequestError, Strategy.OAuth}
+  alias Assent.{Config.MissingKeyError, MissingParamError, RequestError, Strategy.OAuth}
 
   @private_key """
     -----BEGIN RSA PRIVATE KEY-----
@@ -261,6 +261,22 @@ defmodule Assent.Strategy.OAuthTest do
       config = Keyword.put(config, :user_url, "/api/user")
 
       {:ok, config: config}
+    end
+
+    test "with missing oauth_token param", %{config: config, callback_params: params} do
+      params = Map.delete(params, "oauth_token")
+
+      assert {:error, %MissingParamError{} = error} = OAuth.callback(config, params)
+      assert error.message == "Expected \"oauth_token\" to exist in params, but only found the following keys: [\"oauth_verifier\"]"
+      assert error.params == %{"oauth_verifier" => "hfdp7dh39dks9884"}
+    end
+
+    test "with missing oauth_verifier param", %{config: config, callback_params: params} do
+      params = Map.delete(params, "oauth_verifier")
+
+      assert {:error, %MissingParamError{} = error} = OAuth.callback(config, params)
+      assert error.message == "Expected \"oauth_verifier\" to exist in params, but only found the following keys: [\"oauth_token\"]"
+      assert error.params == %{"oauth_token" => "hh5s93j4hdidpola"}
     end
 
     test "with missing `:site` config", %{config: config, callback_params: callback_params} do

--- a/test/assent/strategies/twitter_test.exs
+++ b/test/assent/strategies/twitter_test.exs
@@ -1,7 +1,7 @@
 defmodule Assent.Strategy.TwitterTest do
   use Assent.Test.OAuthTestCase
 
-  alias Assent.Strategy.Twitter
+  alias Assent.{CallbackError, Strategy.Twitter}
 
   # From https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
   @user_response %{
@@ -151,5 +151,12 @@ defmodule Assent.Strategy.TwitterTest do
 
     assert {:ok, %{user: user}} = Twitter.callback(config, params)
     assert user == @user
+  end
+
+  test "callback/2 when user denies", %{config: config, callback_params: params} do
+    assert {:error, %CallbackError{} = error} = Twitter.callback(config, %{"denied" => params["oauth_token"]})
+    assert error.message == "The user denied the authorization request"
+    refute error.error
+    refute error.error_uri
   end
 end


### PR DESCRIPTION
The OAuth 1.0a strategies didn't handle error redirect params at all. This PR resolves that.