### PR TITLE
Fix azure ad strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.22 (TBA)
 
 * `Assent.Strategy.OAuth2.fetch_user/4` now accepts headers in arguments
+* `Assent.Strategy.AzureAD` bug fixed so it now uses the `RS256` alg
 
 ## v0.1.21 (2020-12-29)
 

--- a/lib/assent/strategies/azure_ad.ex
+++ b/lib/assent/strategies/azure_ad.ex
@@ -43,8 +43,7 @@ defmodule Assent.Strategy.AzureAD do
     [
       site: "https://login.microsoftonline.com/#{tenant_id}/v2.0",
       authorization_params: [scope: "email profile", response_mode: "form_post"],
-      client_auth_method: :client_secret_post,
-      id_token_signed_response_alg: "HS256"
+      client_authentication_method: "client_secret_post"
     ]
   end
 

--- a/test/assent/strategies/apple_test.exs
+++ b/test/assent/strategies/apple_test.exs
@@ -21,46 +21,14 @@ defmodule Assent.Strategy.AppleTest do
   -----END PUBLIC KEY-----
   """
   # Based on https://developer.apple.com/documentation/signinwithapplerestapi/authenticating_users_with_sign_in_with_apple
-  @id_token elem(Assent.Strategy.sign_jwt(
-    %{
-      "iss" => "https://appleid.apple.com",
-      "sub" => "001473.fe6f6f83bf4b8e4590aacbabdcb8598bd0.2039",
-      "aud" => @client_id,
-      "exp" => :os.system_time(:second) + 5 * 60,
-      "iat" => :os.system_time(:second),
-      "email" => "john.doe@example.com"
-    },
-    "RS256",
-    """
-    -----BEGIN RSA PRIVATE KEY-----
-    MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw
-    kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr
-    m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi
-    NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV
-    3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2
-    QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs
-    kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
-    amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
-    +bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
-    D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
-    0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
-    lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
-    hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
-    bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X
-    +jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B
-    BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC
-    2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx
-    QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz
-    5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9
-    Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0
-    NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j
-    8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma
-    3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K
-    y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB
-    jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=
-    -----END RSA PRIVATE KEY-----
-    """,
-    []), 1)
+  @id_token_claims %{
+    "iss" => "https://appleid.apple.com",
+    "sub" => "001473.fe6f6f83bf4b8e4590aacbabdcb8598bd0.2039",
+    "aud" => @client_id,
+    "exp" => :os.system_time(:second) + 5 * 60,
+    "iat" => :os.system_time(:second),
+    "email" => "john.doe@example.com"
+  }
   @user %{
     "email" => "john.doe@example.com",
     "email_verified" => true,
@@ -98,7 +66,7 @@ defmodule Assent.Strategy.AppleTest do
 
   if :crypto.supports()[:curves] do
     test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
-      expect_oidc_access_token_request(bypass, [id_token: @id_token, uri: "/auth/token"], fn _conn, params ->
+      expect_oidc_access_token_request(bypass, [id_token_opts: [claims: @id_token_claims], uri: "/auth/token"], fn _conn, params ->
         assert {:ok, jwt} = AssentJWT.verify(params["client_secret"], @public_key, json_library: Jason)
         assert jwt.verified?
         assert jwt.header["alg"] == "ES256"
@@ -119,21 +87,15 @@ defmodule Assent.Strategy.AppleTest do
     test "callback/2 with name scope", %{config: config, callback_params: params, bypass: bypass} do
       expected_user = Map.merge(@user, %{"given_name" => "John", "family_name" => "Doe"})
 
-      opts = [
-        params: %{
-          access_token: "access_token",
-          id_token: @id_token,
-          user: %{
-            email: "john.doe2@example.com",
-            name: %{
-              firstName: "John",
-              lastName: "Doe"
-            }
-          }
-        },
-        uri: "/auth/token"]
+      user = %{
+        email: "john.doe@example.com",
+        name: %{
+          firstName: "John",
+          lastName: "Doe"
+        }
+      }
 
-      expect_oidc_access_token_request(bypass, opts)
+      expect_oidc_access_token_request(bypass, id_token_opts: [claims: @id_token_claims, kid: @jwk["kid"]], uri: "/auth/token", params: %{user: user, access_token: "access_token"})
       expect_oidc_jwks_uri_request(bypass, uri: "/auth/keys", keys: [@jwk])
 
       assert {:ok, %{user: user}} = Apple.callback(config, params)

--- a/test/assent/strategies/azure_ad_test.exs
+++ b/test/assent/strategies/azure_ad_test.exs
@@ -4,7 +4,7 @@ defmodule Assent.Strategy.AzureADTest do
   alias Assent.Strategy.AzureAD
 
   # From https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
-  @id_token elem(Assent.Strategy.sign_jwt(%{
+  @id_token_claims %{
     "ver" => "2.0",
     "iss" => "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
     "sub" => "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ",
@@ -18,7 +18,7 @@ defmodule Assent.Strategy.AzureADTest do
     "tid" => "3338040d-6c67-4c5b-b112-36a304b66dad",
     "nonce" => "123523",
     "aio" => "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY"
-  }, "HS256", "secret", []), 1)
+  }
   @user %{
     "name" => "Abe Lincoln",
     "preferred_username" => "AbeLi@microsoft.com",
@@ -33,11 +33,16 @@ defmodule Assent.Strategy.AzureADTest do
   end
 
   test "callback/2", %{config: config, callback_params: params, bypass: bypass} do
-    openid_config  = Map.merge(config[:openid_configuration], %{"issuer" => "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"})
+    openid_config =
+      config[:openid_configuration]
+      |> Map.put("issuer", "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0")
+      |> Map.put("token_endpoint_auth_methods_supported", ["client_secret_post", "private_key_jwt", "client_secret_basic"])
+
     session_params = Map.put(config[:session_params], :nonce, "123523")
     config         = Keyword.merge(config, openid_configuration: openid_config, tenant_id: "9188040d-6c67-4c5b-b112-36a304b66dad", client_id: "6cb04018-a3f5-46a7-b995-940c78f5aef3", session_params: session_params)
 
-    expect_oidc_access_token_request(bypass, id_token: @id_token)
+    [key | _rest] = expect_oidc_jwks_uri_request(bypass)
+    expect_oidc_access_token_request(bypass, id_token_opts: [claims: @id_token_claims, kid: key["kid"]])
 
     assert {:ok, %{user: user}} = AzureAD.callback(config, params)
     assert user == @user

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -125,6 +125,8 @@ defmodule Assent.Test.OIDCTestCase do
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.send_resp(200, Jason.encode!(%{"keys" => keys}))
     end)
+
+    keys
   end
 
   @spec expect_oidc_userinfo_request(Bypass.t(), map() | binary(), Keyword.t()) :: :ok


### PR DESCRIPTION
#59 changed the alg to HS256, but Azure AD uses RS256 to sign the id tokens.