### PR TITLE
Handle missing id_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Updated to support OTP 24 and no longer support OTP < 22.1
 
+* `Assent.Strategy.OIDC` now handles missing `id_token` in token params
+
 ## v0.1.22 (2021-01-08)
 
 * `Assent.Strategy.OAuth2.fetch_user/4` now accepts headers in arguments

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -228,8 +228,16 @@ defmodule Assent.Strategy.OIDC do
   """
   @spec fetch_user(Config.t(), map()) :: {:ok, map()} | {:error, term()}
   def fetch_user(config, token) do
-    with {:ok, jwt} <- validate_id_token(config, token["id_token"]) do
+    with {:ok, id_token} <- fetch_id_token(token),
+         {:ok, jwt}      <- validate_id_token(config, id_token) do
       Helpers.normalize_userinfo(jwt.claims)
+    end
+  end
+
+  defp fetch_id_token(token) do
+    case Map.fetch(token, "id_token") do
+      {:ok, id_token} -> {:ok, id_token}
+      :error          -> {:error, "The `id_token` key not found in token params, only found these keys: #{Enum.join(Map.keys(token), ", ")}"}
     end
   end
 

--- a/test/assent/strategies/apple_test.exs
+++ b/test/assent/strategies/apple_test.exs
@@ -95,7 +95,7 @@ defmodule Assent.Strategy.AppleTest do
         }
       }
 
-      expect_oidc_access_token_request(bypass, id_token_opts: [claims: @id_token_claims, kid: @jwk["kid"]], uri: "/auth/token", params: %{user: user, access_token: "access_token"})
+      expect_oidc_access_token_request(bypass, id_token_opts: [claims: @id_token_claims, kid: @jwk["kid"]], uri: "/auth/token", additional_params: %{user: user})
       expect_oidc_jwks_uri_request(bypass, uri: "/auth/keys", keys: [@jwk])
 
       assert {:ok, %{user: user}} = Apple.callback(config, params)

--- a/test/assent/strategies/oidc_test.exs
+++ b/test/assent/strategies/oidc_test.exs
@@ -153,6 +153,14 @@ defmodule Assent.Strategy.OIDCTest do
       assert OIDC.callback(config, params) == {:error, "The ID Token is not a valid JWT"}
     end
 
+    test "with missing id_token", %{config: config, openid_config: openid_config, callback_params: params, bypass: bypass} do
+      expect_openid_config_request(bypass, openid_config)
+
+      expect_oidc_access_token_request(bypass, uri: "/dynamic/token/path", params: %{access_token: "access_token", renewal_token: "renewal_token"})
+
+      assert OIDC.callback(config, params) ==  {:error, "The `id_token` key not found in token params, only found these keys: access_token, renewal_token"}
+    end
+
     test "with valid id_token", %{config: config, openid_config: openid_config, callback_params: params, bypass: bypass} do
       expect_openid_config_request(bypass, openid_config)
 

--- a/test/support/strategies/oidc_test_case.ex
+++ b/test/support/strategies/oidc_test_case.ex
@@ -104,8 +104,8 @@ defmodule Assent.Test.OIDCTestCase do
 
     params =
       opts
-      |> Keyword.get(:params, %{access_token: "access_token"})
-      |> Map.put_new(:id_token, id_token)
+      |> Keyword.get(:params, %{access_token: "access_token", id_token: id_token})
+      |> Map.merge(Keyword.get(opts, :additional_params, %{}))
 
     opts =
       opts


### PR DESCRIPTION
I've experienced that in some circumstances there's no `id_token` returned during Apple Sign In callback. This PR handles missing `id_token` in token params for OIDC strategy gracefully.