### PR TITLE
Fix KeyError caused by RequestError fetching invalid site openid configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.24 (TBA)
+
+* `Assent.Strategy.OIDC.Base.authorize_url/2` now has correct type specs
+
 ## v0.1.23 (2021-03-01)
 
 Updated to support OTP 24 and no longer support OTP < 22.1

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -116,6 +116,9 @@ defmodule Assent.Strategy.OIDC do
         {:ok, %HTTPResponse{status: 200, body: configuration}} ->
           {:ok, configuration}
 
+        {:error, %RequestError{} = response} ->
+          {:error, response}
+
         {:error, response} ->
           {:error, RequestError.invalid(response)}
       end

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -116,9 +116,6 @@ defmodule Assent.Strategy.OIDC do
         {:ok, %HTTPResponse{status: 200, body: configuration}} ->
           {:ok, configuration}
 
-        {:error, %RequestError{} = response} ->
-          {:error, response}
-
         {:error, response} ->
           {:error, RequestError.invalid(response)}
       end

--- a/lib/assent/strategies/oidc/base.ex
+++ b/lib/assent/strategies/oidc/base.ex
@@ -45,7 +45,7 @@ defmodule Assent.Strategy.OIDC.Base do
     end
   end
 
-  @spec authorize_url(Keyword.t(), module()) :: {:ok, %{session_params: %{state: binary()} | %{state: binary(), nonce: binary()}, url: binary()}}
+  @spec authorize_url(Keyword.t(), module()) :: {:ok, %{session_params: %{state: binary()} | %{state: binary(), nonce: binary()}, url: binary()}} | {:error, term()}
   def authorize_url(config, strategy) do
     config
     |> set_config(strategy)

--- a/lib/assent/strategy.ex
+++ b/lib/assent/strategy.ex
@@ -65,14 +65,14 @@ defmodule Assent.Strategy do
   @doc """
   Decodes a request response.
   """
-  @spec decode_response({atom(), any()}, Config.t()) :: {atom(), any()}
-  def decode_response({status, %{body: body, headers: headers} = resp}, config) do
+  @spec decode_response({:ok, HTTPResponse.t()} | {:error, HTTPResponse.t()} | {:error. term()}, Config.t()) :: {:ok, HTTPResponse.t()} | {:error, HTTPResponse.t()} | {:error, term()}
+  def decode_response({ok_or_error, %{body: body, headers: headers} = resp}, config) do
     case decode_body(headers, body, config) do
-      {:ok, body}     -> {status, %{resp | body: body}}
+      {:ok, body}     -> {ok_or_error, %{resp | body: body}}
       {:error, error} -> {:error, error}
     end
   end
-  def decode_response(any, _config), do: any
+  def decode_response({:error, reason}, _config), do: {:error, reason}
 
   defp decode_body(headers, body, config) do
     case List.keyfind(headers, "content-type", 0) do

--- a/test/assent/strategy_test.exs
+++ b/test/assent/strategy_test.exs
@@ -4,25 +4,28 @@ defmodule Assent.StrategyTest do
 
   alias Assent.Strategy
 
-  test "decode_response/1" do
+  test "decode_response/2" do
     expected = %{"a" => "1", "b" => "2"}
 
     headers = [{"content-type", "application/json"}]
     body = Jason.encode!(expected)
-    assert Strategy.decode_response({nil, %{body: body, headers: headers}}, []) == {nil, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:ok, %{body: body, headers: headers}}, []) == {:ok, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:error, %{body: body, headers: headers}}, []) == {:error, %{body: expected, headers: headers}}
 
     headers = [{"content-type", "application/json; charset=utf-8"}]
-    assert Strategy.decode_response({nil, %{body: body, headers: headers}}, []) == {nil, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:ok, %{body: body, headers: headers}}, []) == {:ok, %{body: expected, headers: headers}}
 
     headers = [{"content-type", "text/javascript"}]
-    assert Strategy.decode_response({nil, %{body: body, headers: headers}}, []) == {nil, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:ok, %{body: body, headers: headers}}, []) == {:ok, %{body: expected, headers: headers}}
 
     headers = [{"content-type", "application/x-www-form-urlencoded"}]
     body = URI.encode_query(expected)
-    assert Strategy.decode_response({nil, %{body: body, headers: headers}}, []) == {nil, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:ok, %{body: body, headers: headers}}, []) == {:ok, %{body: expected, headers: headers}}
 
     headers = [{"content-type", "application/x-www-form-urlencoded; charset=utf-8"}]
-    assert Strategy.decode_response({nil, %{body: body, headers: headers}}, []) == {nil, %{body: expected, headers: headers}}
+    assert Strategy.decode_response({:ok, %{body: body, headers: headers}}, []) == {:ok, %{body: expected, headers: headers}}
+
+    assert Strategy.decode_response({:error, "error reason"}, []) == {:error, "error reason"}
   end
 
   defmodule JSONMock do


### PR DESCRIPTION
I recently ran into an issue with some code I wrote. I wanted to pattern match on any errors when generating the authorize_url and was getting a KeyError that wouldn't let me hit the error clause below. I finally noticed I had a typo in my `:site` configuration so it was not able to connect to the site and an error was being thrown. 

```elixir
case ProjectWeb.Strategy.authorize_url(oidc_config) do
  {:ok, %{url: url, session_params: %{state: state, nonce: nonce}}} ->
    conn
    |> put_session("state", state)
    |> put_session("nonce", nonce)
    |> redirect(external: url)

  # Was getting a warning this would never match
  {:error, _reason} ->
    # KeyError would not let this logic execute
    redirect(conn, to: "/")
end
```

This PR addresses what was causing the KeyError to occur and fixes the typespec to allow the error clause above to work without the nice squiggly yellow warning line in my editor.