### PR TITLE
Propagate existing RequestError in fetch_openid_configuration

### DIFF
--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -116,6 +116,9 @@ defmodule Assent.Strategy.OIDC do
         {:ok, %HTTPResponse{status: 200, body: configuration}} ->
           {:ok, configuration}
 
+        {:error, %RequestError{} = error} ->
+          {:error, error}
+
         {:error, response} ->
           {:error, RequestError.invalid(response)}
       end


### PR DESCRIPTION
`Assent.Strategy.request` can return `RequestError{error: :unreachable}` in `OIDC.fetch_openid_configuration/1`.

Passing an existing `%RequestError{}` struct into `RequestError.invalid/1` causes a `KeyError` accessing the `:status` field.

The changes in this PR pattern match to handle `%RequestError{}` and return it.


---

The stacktrace:

```
** (KeyError) key :status not found in: 
%Assent.RequestError{
  error: :unreachable, 
  message: "Server was unreachable with MyAppWeb.HTTPAdapater.\n\nFailed with the following error:\n\"socket closed\"\n\nURL: https://****/.well-known/openid-configuration\n"
}
```

```
lib/assent.ex:52 Assent.RequestError.invalid/1 
lib/assent/strategies/oidc.ex:120 Assent.Strategy.OIDC.fetch_openid_configuration/1 
lib/assent/strategies/oidc.ex:89 Assent.Strategy.OIDC.authorize_url/1 
lib/myapp_web/my_oidc.ex:46 MyAppWeb.MyOIDC.authorise_url/1   
lib/myapp_web/controllers/session_controller.ex:18 MyAppWeb.SessionController.authorise/2 
lib/myapp_web/controllers/session_controller.ex:1 MyAppWeb.SessionController.action/2 
lib/myapp_web/controllers/session_controller.ex:1 MyAppWeb.SessionController.phoenix_controller_pipeline/2 
lib/phoenix/router.ex:355 Phoenix.Router.__call__/2
```