### PR TITLE
Update slack to use OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 In previous `Assent.Stategy.Slack` strategy, the `sub` user id field consisted of `{SUB}-{TEAM}`. Slack has migrated to OpenID Connect, and the response has been conformed to OIDC. The `sub` will now only consists of the `sub` id, and not include team id. To succesfullly migrate to this release all slack identity records storing the `sub` user id field has to be updated.
 
+If you wish to continue using the previous `sub` user id a custom OIDC strategy can be used instead:
+
+```elixir
+defmodule Slack do
+  use Assent.Strategy.OIDC.Base
+
+  alias Assent.Strategy.Slack
+
+  defdelegate default_config(config), to: Slack
+
+  def normalize(config, user) do
+    user = Map.put(user, "sub", "#{user["https://slack.com/user_id"]}-#{user["https://slack.com/team_id"]}")
+
+    Slack.normalize(config, user)
+  end
+end
+```
+
 * `Assent.Strategy.OIDC.fetch_user/2` now removes the ID token specific keys from the user claims instead of normalizing
 * `Assent.Strategy.OIDC.Base` now adds `normalize/2` to the macro that will include the full user claims in the user params
 * `Assent.Stategy.Slack` now uses OpenID connect instead of legacy OAuth 2.0, please note that the `sub` value may have changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## v0.1.29 (TBA)
+## v0.2.0 (TBA)
+
+**This release consists of breaking changes.**
+
+In previous `Assent.Stategy.Slack` strategy, the `sub` user id field consisted of `{SUB}-{TEAM}`. Slack has migrated to OpenID Connect, and the response has been conformed to OIDC. The `sub` will now only consists of the `sub` id, and not include team id. To succesfullly migrate to this release all slack identity records storing the `sub` user id field has to be updated.
 
 * `Assent.Strategy.OIDC.fetch_user/2` now removes the ID token specific keys from the user claims instead of normalizing
 * `Assent.Strategy.OIDC.Base` now adds `normalize/2` to the macro that will include the full user claims in the user params
+* `Assent.Stategy.Slack` now uses OpenID connect instead of legacy OAuth 2.0, please note that the `sub` value may have changed
 
 ## v0.1.28 (2021-09-30)
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ defmodule TestProvider do
       # },
       # # Provider specific data not part of the standard claims spec
       # %{
-      #   "test_provider_bio" => user["bio"]
+      #   "http://localhost:4000/bio" => user["bio"]
       }
     }
   end

--- a/lib/assent/strategies/oauth/base.ex
+++ b/lib/assent/strategies/oauth/base.ex
@@ -30,7 +30,7 @@ defmodule Assent.Strategy.OAuth.Base do
             # },
             # # Provider specific data not part of the standard claims spec
             # %{
-            #  "bio" => user["bio"]
+            #  "https://example.com/bio" => user["bio"]
             }
           }
         end

--- a/lib/assent/strategies/oauth2/base.ex
+++ b/lib/assent/strategies/oauth2/base.ex
@@ -25,7 +25,7 @@ defmodule Assent.Strategy.OAuth2.Base do
             # },
             # # Provider specific data not part of the standard claims spec
             # %{
-            #  "bio" => user["bio"]
+            #  "https://example.com/bio" => user["bio"]
             }
           }
         end

--- a/test/assent/strategies/slack_test.exs
+++ b/test/assent/strategies/slack_test.exs
@@ -1,47 +1,91 @@
 defmodule Assent.Strategy.SlackTest do
-  use Assent.Test.OAuth2TestCase
+  use Assent.Test.OIDCTestCase
 
   alias Assent.Strategy.Slack
 
-  # From https://api.slack.com/methods/users.identity
-  @user_response %{
-    "ok" => true,
-    "user" => %{
-      "name" => "Sonny Whether",
-      "id" => "U0G9QF9C6",
-      "email" => "sonny@captain-fabian.com",
-      "image_24" => "https://cdn.example.com/sonny_24.jpg",
-      "image_32" => "https://cdn.example.com/sonny_32.jpg",
-      "image_48" => "https://cdn.example.com/sonny_48.jpg",
-      "image_72" => "https://cdn.example.com/sonny_72.jpg",
-      "image_192" => "https://cdn.example.com/sonny_192.jpg"
-    },
-    "team" => %{
-      "id" => "T0G9PQBBK",
-      "name" => "Captain Fabian's Naval Supply"
-    }
+  # From https://api.slack.com/authentication/sign-in-with-slack#implementation
+  @id_token_claims %{
+    "iss" => "https://slack.com",
+    "sub" => "U0R7MFMJM",
+    "aud" => "25259531569.1115258246291",
+    "exp" => :os.system_time(:second) + 60,
+    "iat" => :os.system_time(:second),
+    "auth_time" => :os.system_time(:second),
+    "nonce" => "abcd",
+    "at_hash" => "tUbyWGBHe0V32FJEupkgVQ",
+    "https://slack.com/team_id" => "T0RR",
+    "https://slack.com/user_id" => "U0JM",
+    "email" => "bront@slack-corp.com",
+    "email_verified" => true,
+    "date_email_verified" => 1_622_128_723,
+    "locale" => "en-US",
+    "name" => "brent",
+    "given_name" => "",
+    "family_name" => "",
+    "https://slack.com/team_image_230" => "https://secure.gravatar.com/avatar/bc.png",
+    "https://slack.com/team_image_default" => true
   }
+
   @user %{
-    "email" => "sonny@captain-fabian.com",
-    "name" => "Sonny Whether",
-    "picture" => "https://cdn.example.com/sonny_48.jpg",
-    "slack_team" => %{
-      "id" => "T0G9PQBBK",
-      "name" => "Captain Fabian's Naval Supply"
-    },
-    "sub" => "U0G9QF9C6-T0G9PQBBK"
+    "sub" => "U0R7MFMJM",
+    "name" => "brent",
+    "email" => "bront@slack-corp.com",
+    "email_verified" => true,
+    "family_name" => "",
+    "given_name" => "",
+    "locale" => "en-US",
+    "https://slack.com/team_id" => "T0RR",
+    "https://slack.com/user_id" => "U0JM",
+    "date_email_verified" => 1_622_128_723,
+    "https://slack.com/team_image_230" => "https://secure.gravatar.com/avatar/bc.png",
+    "https://slack.com/team_image_default" => true
   }
+
+  @openid_config %{
+    "issuer" => "https://slack.com",
+    "authorization_endpoint" => "https://slack.com/openid/connect/authorize",
+    "token_endpoint" => "https://slack.com/api/openid.connect.token",
+    "userinfo_endpoint" => "https://slack.com/api/openid.connect.userInfo",
+    "jwks_uri" => "https://slack.com/openid/connect/keys",
+    "scopes_supported" => ["openid", "profile", "email"],
+    "response_types_supported" => ["code"],
+    "response_modes_supported" => ["form_post"],
+    "grant_types_supported" => ["authorization_code"],
+    "subject_types_supported" => ["public"],
+    "id_token_signing_alg_values_supported" => ["RS256"],
+    "claims_supported" => ["sub", "auth_time", "iss"],
+    "claims_parameter_supported" => false,
+    "request_parameter_supported" => false,
+    "request_uri_parameter_supported" => true,
+    "token_endpoint_auth_methods_supported" => ["client_secret_post", "client_secret_basic"]
+  }
+
+  setup %{config: config} do
+    openid_configuration = Map.merge(@openid_config, Map.delete(config[:openid_configuration], "issuer"))
+
+    config = Keyword.put(config, :openid_configuration, openid_configuration)
+
+    {:ok, config: config}
+  end
 
   test "authorize_url/2", %{config: config} do
     assert {:ok, %{url: url}} = Slack.authorize_url(config)
     assert url =~ "/oauth/authorize?client_id="
+    assert url =~ "scope=openid+openid+email+profile"
+  end
+
+  test "authorize_url/2 with team config", %{config: config} do
+    assert {:ok, %{url: url}} = Slack.authorize_url(Keyword.put(config, :team_id, "team_id"))
+    assert url =~ "&team=team_id"
   end
 
   test "callback/2", %{config: config, callback_params: params} do
-    expect_oauth2_access_token_request([uri: "/api/oauth.access"], fn _conn, params ->
-      assert params["client_secret"] == config[:client_secret]
-    end)
-    expect_oauth2_user_request(@user_response, uri: "/api/users.identity")
+    claims = Map.put(@id_token_claims, "aud", config[:client_id])
+    session_params = Map.put(config[:session_params], :nonce, @id_token_claims["nonce"])
+    config = Keyword.put(config, :session_params, session_params)
+
+    [key | _rest] = expect_oidc_jwks_uri_request()
+    expect_oidc_access_token_request(id_token_opts: [claims: claims, kid: key["kid"]])
 
     assert {:ok, %{user: user}} = Slack.callback(config, params)
     assert user == @user


### PR DESCRIPTION
Unfortunately this introduces a breaking change to the `sub` field, as it now no longer include the team id.