### PR TITLE
Fix `use Bitwise` deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.1 (TBA)
 
 * Default to using `Jason` instead of `Poison` for JSON parsing
+* Fixed `Bitwise` warning when running on Elixir 1.14
 
 ## v0.2.0 (2022-03-01)
 

--- a/lib/assent.ex
+++ b/lib/assent.ex
@@ -77,7 +77,7 @@ defmodule Assent do
     end
   end
 
-  use Bitwise
+  import Bitwise
 
   @doc false
   @spec constant_time_compare(binary(), binary()) :: boolean()


### PR DESCRIPTION
Fix for this warning:

```
warning: use Bitwise is deprecated. import Bitwise instead
```