### PR TITLE
Allow status code 201 for access token response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2 (TBA)
+
+* Fixed bug to handle 201 success response
+
 ## v0.2.1 (2022-09-15)
 
 * Default to using `Jason` instead of `Poison` for JSON parsing

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -260,7 +260,7 @@ defmodule Assent.Strategy.OAuth2 do
     end
   end
 
-  defp process_access_token_response({:ok, %HTTPResponse{status: 200, body: %{"access_token" => _} = token}}), do: {:ok, token}
+  defp process_access_token_response({:ok, %HTTPResponse{status: status, body: %{"access_token" => _} = token}}) when status in [200, 201], do: {:ok, token}
   defp process_access_token_response(any), do: process_response(any)
 
   defp process_response({:ok, %HTTPResponse{} = response}), do: {:error, RequestError.unexpected(response)}

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -329,9 +329,8 @@ defmodule Assent.Strategy.OAuth2Test do
       assert {:ok, _any} = OAuth2.callback(config, params)
     end
 
-    test "with access token with 201 response", %{config: config, callback_params: params} do
+    test "with 201 response", %{config: config, callback_params: params} do
       expect_oauth2_access_token_request(status_code: 201)
-
       expect_oauth2_user_request(@user_api_params)
 
       assert {:ok, _any} = OAuth2.callback(config, params)

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -329,6 +329,14 @@ defmodule Assent.Strategy.OAuth2Test do
       assert {:ok, _any} = OAuth2.callback(config, params)
     end
 
+    test "with access token with 201 response", %{config: config, callback_params: params} do
+      expect_oauth2_access_token_request(status_code: 201)
+
+      expect_oauth2_user_request(@user_api_params)
+
+      assert {:ok, _any} = OAuth2.callback(config, params)
+    end
+
     test "normalizes data", %{config: config, callback_params: params} do
       expect_oauth2_access_token_request()
       expect_oauth2_user_request(@user_api_params)


### PR DESCRIPTION
My OAuth2 provider ([Harvest](https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/)) is using HTTP status code `201 Created` for the access token response.