### PR TITLE
Add support for multiple audiences with OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.2 (TBA)
 
 * Fixed bug to handle 201 success response
+* `Assent.Strategy.OIDC` now has support for multiple audiences
 
 ## v0.2.1 (2022-09-15)
 


### PR DESCRIPTION
Resolves #111.

It's required to set a list of trusted audiences in the config:

```elixir
config =  [
  client_id: "REPLACE_WITH_CLIENT_ID",
  site: "https://server.example.com",
  authorization_params: [scope: "user:read user:write"],
  trusted_audiences: ~w(aud1 aud2)
]
```