### PR TITLE
Permit any auth method by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed bug to handle 201 success response
 * `Assent.Strategy.OIDC` now has support for multiple audiences
+* `Assent.Strategy.OIDC` now permits any auth method if no `token_endpoint_auth_methods_supported` specified
 
 ## v0.2.1 (2022-09-15)
 

--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -205,9 +205,11 @@ defmodule Assent.Strategy.OIDC do
 
   defp fetch_client_authentication_method(openid_config, config) do
     method  = Config.get(config, :client_authentication_method, "client_secret_basic")
-    methods = Map.get(openid_config, "token_endpoint_auth_methods_supported", ["client_secret_basic"])
+    methods = Map.get(openid_config, "token_endpoint_auth_methods_supported")
 
-    case method in methods do
+    supported_method? = if is_nil(methods), do: true, else: method in methods
+
+    case supported_method? do
       true  -> to_client_auth_method(method)
       false -> {:error, "Unsupported client authentication method: #{method}"}
     end


### PR DESCRIPTION
Working on #115 uncovered this issue.

I'm unsure exactly what's meant [in the RFC](https://www.rfc-editor.org/rfc/rfc8414.html#section-2):

```
token_endpoint_auth_methods_supported
      OPTIONAL.  JSON array containing a list of client authentication
      methods supported by this token endpoint.  Client authentication
      method values are used in the "token_endpoint_auth_method"
      parameter defined in [Section 2 of [RFC7591]](https://www.rfc-editor.org/rfc/rfc7591#section-2).  If omitted, the
      default is "client_secret_basic" -- the HTTP Basic Authentication
      Scheme specified in [Section 2.3.1](https://www.rfc-editor.org/rfc/rfc8414.html#section-2.3.1) of OAuth 2.0 [[RFC6749](https://www.rfc-editor.org/rfc/rfc6749)].
```

This PR errs on the side of just allowing any valid auth method if the server doesn't specify any.