### PR TITLE
Add Strava strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7 (TBA)
+
+* `Assent.Strategy.Strava` added
+
 ## v0.2.6 (2023-08-26)
 
 * Added `Assent.HTTPAdapter.Finch`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Multi-provider authentication framework.
   * LINE Login - `Assent.Strategy.LINE`
   * Linkedin - `Assent.Strategy.Linkedin`
   * Spotify - `Assent.Strategy.Spotify`
+  * Strava - `Assent.Strategy.Strava`
   * Slack - `Assent.Strategy.Slack`
   * Stripe Connect - `Assent.Strategy.Stripe`
   * Twitter - `Assent.Strategy.Twitter`

--- a/lib/assent/strategies/strava.ex
+++ b/lib/assent/strategies/strava.ex
@@ -1,0 +1,42 @@
+defmodule Assent.Strategy.Strava do
+  @moduledoc """
+  Strava OAuth strategy.
+
+  The athlete endpoint, describing the currently authenticated user, does not
+  return an email address - [changelog](https://developers.strava.com/docs/changelog/#january-17-2019).
+
+  ## Usage
+
+      config = [
+        client_id: "REPLACE_WITH_CLIENT_ID",
+        client_secret: "REPLACE_WITH_CLIENT_SECRET"
+      ]
+
+  See `Assent.Strategy.OAuth2` for more.
+  """
+  use Assent.Strategy.OAuth2.Base
+
+  @impl true
+  def default_config(_config) do
+    [
+      site: "https://www.strava.com/api/v3",
+      authorize_url: "https://www.strava.com/oauth/authorize",
+      token_url: "/oauth/token",
+      user_url: "/athlete",
+      authorization_params: [scope: "read_all,profile:read_all"],
+      auth_method: :client_secret_post
+    ]
+  end
+
+  @impl true
+  def normalize(_config, user) do
+    {:ok,
+     %{
+       "sub" => user["id"],
+       "given_name" => user["firstname"],
+       "family_name" => user["lastname"],
+       "preferred_username" => user["username"],
+       "picture" => user["profile"]
+     }}
+  end
+end

--- a/test/assent/strategies/strava_test.exs
+++ b/test/assent/strategies/strava_test.exs
@@ -1,0 +1,86 @@
+defmodule Assent.Strategy.StravaTest do
+  use Assent.Test.OAuth2TestCase
+
+  alias Assent.Strategy.Strava
+
+  # Sample from https://developers.strava.com/docs/reference/#api-Athletes-getLoggedInAthlete
+  @user_response %{
+    "id" => 1_234_567_890_987_654_321,
+    "username" => "marianne_t",
+    "resource_state" => 3,
+    "firstname" => "Marianne",
+    "lastname" => "Teutenberg",
+    "city" => "San Francisco",
+    "state" => "CA",
+    "country" => "US",
+    "sex" => "F",
+    "premium" => true,
+    "created_at" => "2017-11-14T02:30:05Z",
+    "updated_at" => "2018-02-06T19:32:20Z",
+    "badge_type_id" => 4,
+    "profile_medium" =>
+      "https://xxxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/medium.jpg",
+    "profile" => "https://xxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg",
+    "friend" => nil,
+    "follower" => nil,
+    "follower_count" => 5,
+    "friend_count" => 5,
+    "mutual_friend_count" => 0,
+    "athlete_type" => 1,
+    "date_preference" => "%m/%d/%Y",
+    "measurement_preference" => "feet",
+    "clubs" => [],
+    "ftp" => nil,
+    "weight" => 0,
+    "bikes" => [
+      %{
+        "id" => "b12345678987655",
+        "primary" => true,
+        "name" => "EMC",
+        "resource_state" => 2,
+        "distance" => 0
+      }
+    ],
+    "shoes" => [
+      %{
+        "id" => "g12345678987655",
+        "primary" => true,
+        "name" => "adidas",
+        "resource_state" => 2,
+        "distance" => 4904
+      }
+    ]
+  }
+
+  @user %{
+    "sub" => 1_234_567_890_987_654_321,
+    "given_name" => "Marianne",
+    "family_name" => "Teutenberg",
+    "preferred_username" => "marianne_t",
+    "picture" => "https://xxxxx.cloudfront.net/pictures/athletes/123456789/123456789/2/large.jpg"
+  }
+
+  test "authorize_url/2", %{config: config} do
+    assert {:ok, %{url: url}} = Strava.authorize_url(config)
+    assert url =~ "https://www.strava.com/oauth/authorize?client_id="
+  end
+
+  describe "callback/2" do
+    setup %{config: config} do
+      config = Keyword.put(config, :token_url, TestServer.url("/login/oauth/access_token"))
+
+      {:ok, config: config}
+    end
+
+    test "normalizes data", %{config: config, callback_params: params} do
+      expect_oauth2_access_token_request([uri: "/login/oauth/access_token"], fn _conn, params ->
+        assert params["client_secret"] == config[:client_secret]
+      end)
+
+      expect_oauth2_user_request(@user_response, uri: "/athlete")
+
+      assert {:ok, %{user: user}} = Strava.callback(config, params)
+      assert user == @user
+    end
+  end
+end


### PR DESCRIPTION
I made a custom strategy for authenticating with [Strava](https://www.strava.com/). I'd love to have it as a community supported option, if there would be any interest in it.

## References

- [Authentication flow for Strava](https://developers.strava.com/docs/authentication/)
- [Reason why email was removed](https://groups.google.com/g/strava-api/c/vF__o7ttoAQ/m/eb6JdcLYCwAJ)