### PR TITLE
Create the temporary directory before writing the cert file

### DIFF
--- a/test/assent/http_adapter/httpc_test.exs
+++ b/test/assent/http_adapter/httpc_test.exs
@@ -11,6 +11,7 @@ defmodule Assent.HTTPAdapter.HttpcTest do
 
       assert {:ok, %HTTPResponse{status: 200, body: "HTTP/1.1"}} = Httpc.request(:get, TestServer.url(), nil, [], ssl: [cacerts: TestServer.x509_suite().cacerts])
 
+      File.mkdir_p!("tmp")
       File.write!("tmp/cacerts.pem", :public_key.pem_encode(Enum.map(TestServer.x509_suite().cacerts, &{:Certificate, &1, :not_encrypted})))
       TestServer.add("/", via: :get)
 

--- a/test/assent/strategies/oauth2_test.exs
+++ b/test/assent/strategies/oauth2_test.exs
@@ -308,7 +308,7 @@ defmodule Assent.Strategy.OAuth2Test do
     end
 
     test "with `:private_key_jwt` auth method with private key as file", %{config: config, callback_params: params} do
-      File.mkdir("tmp/")
+      File.mkdir_p!("tmp/")
       File.write!("tmp/private-key.pem", @private_key)
 
       config =

--- a/test/assent/strategies/oauth_test.exs
+++ b/test/assent/strategies/oauth_test.exs
@@ -231,7 +231,7 @@ defmodule Assent.Strategy.OAuthTest do
     end
 
     test "with `:private_key_path` config", %{config: config} do
-      File.mkdir("tmp/")
+      File.mkdir_p!("tmp/")
       File.write!("tmp/private-key.pem", @private_key)
 
       config =


### PR DESCRIPTION
Other tests create expected directory structure in advance (e.g. `File.mkdir_p!("tmp/test_app")`). To prevent execution order issues, create the `tmp` directory here as well.