### PR TITLE
Update MultiProvider example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ defmodule MultiProviderAuth do
   def request(provider) do
     provider
     |> config!()
-    |> config[:strategy].authorize_url()
+    |> then(fn config -> config[:strategy].authorize_url() end)
   end
 
   @spec callback(atom(), map(), map()) :: {:ok, map()} | {:error, term()}
@@ -176,7 +176,7 @@ defmodule MultiProviderAuth do
     provider
     |> config!()
     |> Assent.Config.put(:session_params, session_params)
-    |> config[:strategy].callback(params)
+    |> then(fn config -> config[:strategy].callback(params) end)
   end
 
   defp config!(provider) do


### PR DESCRIPTION
It looks like the changes from 49fcba641536399f3cad793e0cea28a3c64b53a7 made the Multi-provider examples in the Readme invalid - the `config` local variable no longer exists.

This PR adds a `|> then(fn config -> ...` to the pipeline to access the `config` data.