### PR TITLE
Set content-length header in :httpc requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.9 (TBA)
 
 - Fixed bug where `Req` was not used by default if included in project
+- `Assent.Strategy.Httpc.request/5` now sets content length header
 
 ## v0.2.8 (2023-11-19)
 

--- a/lib/assent/http_adapter/httpc.ex
+++ b/lib/assent/http_adapter/httpc.ex
@@ -65,6 +65,7 @@ defmodule Assent.HTTPAdapter.Httpc do
   defp do_httpc_request(url, body, headers) do
     {content_type, headers} = split_content_type_headers(headers)
     body = to_charlist(body)
+    headers = set_content_length_header(headers, body)
 
     {url, headers, content_type, body}
   end
@@ -73,6 +74,17 @@ defmodule Assent.HTTPAdapter.Httpc do
     case List.keytake(headers, ~c"content-type", 0) do
       nil -> {~c"text/plain", headers}
       {{_, ct}, headers} -> {ct, headers}
+    end
+  end
+
+  defp set_content_length_header(headers, body) do
+    case List.keyfind(headers, ~c"content-length", 0) do
+      nil ->
+        length = body |> IO.iodata_length() |> Integer.to_string()
+        [{~c"content-length", length} | headers]
+
+      _ ->
+        headers
     end
   end
 

--- a/test/assent/http_adapter/httpc_test.exs
+++ b/test/assent/http_adapter/httpc_test.exs
@@ -116,6 +116,8 @@ defmodule Assent.HTTPAdapter.HttpcTest do
                    "application/x-www-form-urlencoded"
                  ]
 
+          assert Plug.Conn.get_req_header(conn, "content-length") == ["7"]
+
           Plug.Conn.send_resp(conn, 200, "")
         end
       )


### PR DESCRIPTION
This automatically sets the content length header for :httpc requests.