### PR TITLE
Add state configuration option to OAuth 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.2.11 (TBA)
 
 * Default to using `JSON` instead of `Jason` for JSON parsing on Elixir 1.18
+* Added `:state` config option to OAuth 2.0 strategy
+* Deprecated ability to override `:state` by setting it in `:authorization_params`
 
 ## v0.2.10 (2024-04-11)
 


### PR DESCRIPTION
Refactors how `:state` is handled in the OAuth 2.0. This ensures we always verify the state unless it has been explicitly set to false.