### PR TITLE
Add config support for custom headers in Oauth2 access token request

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ defmodule TestProvider do
       user_url: "/user",
       authorization_params: [scope: "email profile"],
       auth_method: :client_secret_post
+      # Optional: additional headers sent in grant access token request
+      auth_headers: [{"X-Api-Version", "1"}]
     ]
   end
 

--- a/lib/assent.ex
+++ b/lib/assent.ex
@@ -175,6 +175,19 @@ defmodule Assent do
   end
 
   @doc """
+  Fetches the key value from the configuration.
+
+  Returns `default` argument if the key is not found.
+  """
+  @spec fetch_config(Keyword.t(), atom(), any()) :: {:ok, any()}
+  def fetch_config(config, key, default) when is_list(config) and is_atom(key) do
+    case Keyword.fetch(config, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:ok, default}
+    end
+  end
+
+  @doc """
   Fetches the key value from the params.
 
   Returns a `Assent.MissingParamError` if the key is not found.

--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -297,8 +297,9 @@ defmodule Assent.Strategy.OAuth2 do
   end
 
   defp authentication_params(nil, config) do
-    with {:ok, client_id} <- Assent.fetch_config(config, :client_id) do
-      headers = []
+    with {:ok, client_id} <- Assent.fetch_config(config, :client_id),
+         {:ok, auth_headers} <- Assent.fetch_config(config, :auth_headers, []) do
+      headers = auth_headers
       body = [client_id: client_id]
 
       {:ok, headers, body}
@@ -307,9 +308,10 @@ defmodule Assent.Strategy.OAuth2 do
 
   defp authentication_params(:client_secret_basic, config) do
     with {:ok, client_id} <- Assent.fetch_config(config, :client_id),
-         {:ok, client_secret} <- Assent.fetch_config(config, :client_secret) do
+         {:ok, client_secret} <- Assent.fetch_config(config, :client_secret),
+         {:ok, auth_headers} <- Assent.fetch_config(config, :auth_headers, []) do
       auth = Base.encode64("#{client_id}:#{client_secret}")
-      headers = [{"authorization", "Basic #{auth}"}]
+      headers = [{"authorization", "Basic #{auth}"}] ++ auth_headers
       body = []
 
       {:ok, headers, body}
@@ -318,8 +320,9 @@ defmodule Assent.Strategy.OAuth2 do
 
   defp authentication_params(:client_secret_post, config) do
     with {:ok, client_id} <- Assent.fetch_config(config, :client_id),
-         {:ok, client_secret} <- Assent.fetch_config(config, :client_secret) do
-      headers = []
+         {:ok, client_secret} <- Assent.fetch_config(config, :client_secret),
+         {:ok, auth_headers} <- Assent.fetch_config(config, :auth_headers, []) do
+      headers = auth_headers
       body = [client_id: client_id, client_secret: client_secret]
 
       {:ok, headers, body}
@@ -349,8 +352,9 @@ defmodule Assent.Strategy.OAuth2 do
 
   defp jwt_authentication_params(alg, secret, config) do
     with {:ok, claims} <- jwt_claims(config),
-         {:ok, token} <- Helpers.sign_jwt(claims, alg, secret, config) do
-      headers = []
+         {:ok, token} <- Helpers.sign_jwt(claims, alg, secret, config),
+         {:ok, auth_headers} <- Assent.fetch_config(config, :auth_headers, []) do
+      headers = auth_headers
 
       body = [
         client_assertion: token,


### PR DESCRIPTION
I wrote a **PowAssent** custom Oauth2 strategy and controller for a native desktop app, but I ran into auth errors at
https://github.com/pow-auth/assent/blob/cd45572ee626c5f427fccaa153b2445db87eccc7/lib/assent/strategies/oauth2.ex#L280-L288

The third-party service I use requires `"X-Api-Version"` header on access token requests.
I tried setting `headers` in strategy, but it doesn't seem to work.

I propose adding an optional config parameter to allow custom headers in Oauth2 request