### PR TITLE
typo fix in docs (tuple => map in pattern match)

### DIFF
--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -52,7 +52,7 @@ defmodule Assent.Strategy.OAuth2 do
         user_url: "https://example.com/api/user"
       ]
 
-      {:ok, {url: url, session_params: session_params}} =
+      {:ok, %{url: url, session_params: session_params}} =
         config
         |> Assent.Config.put(:redirect_uri, "http://localhost:4000/auth/callback")
         |> Assent.Strategy.OAuth2.authorize_url()


### PR DESCRIPTION
I noted this typo a while ago and made a pull request...

...to my own fork :sweat_smile: now for the real thing.