### PR TITLE
Add support for multiple issuers in OIDC validation

### DIFF
--- a/lib/assent/strategies/oidc.ex
+++ b/lib/assent/strategies/oidc.ex
@@ -443,6 +443,13 @@ defmodule Assent.Strategy.OIDC do
 
   defp validate_issuer_identifier(%{claims: %{"iss" => iss}}, iss), do: :ok
 
+  defp validate_issuer_identifier(%{claims: %{"iss" => iss}}, issuers) when is_list(issuers) do
+    case iss in issuers do
+      true -> :ok
+      false -> {:error, "Invalid issuer \"#{iss}\" in ID Token"}
+    end
+  end
+
   defp validate_issuer_identifier(%{claims: %{"iss" => iss}}, _iss),
     do: {:error, "Invalid issuer \"#{iss}\" in ID Token"}
 

--- a/test/assent/strategies/oidc_test.exs
+++ b/test/assent/strategies/oidc_test.exs
@@ -400,6 +400,34 @@ defmodule Assent.Strategy.OIDCTest do
                {:error, "Invalid issuer \"invalid\" in ID Token"}
     end
 
+    test "with valid `issuer` from list in id_token", %{config: config} do
+      openid_config =
+        Map.put(config[:openid_configuration], "issuer", [
+          "http://localhost",
+          "https://example.com"
+        ])
+
+      config = Keyword.put(config, :openid_configuration, openid_config)
+      id_token = gen_id_token(alg: "HS256", iss: "http://localhost")
+
+      assert {:ok, jwt} = OIDC.validate_id_token(config, id_token)
+      assert jwt.verified?
+    end
+
+    test "with invalid `issuer` not in list in id_token", %{config: config} do
+      openid_config =
+        Map.put(config[:openid_configuration], "issuer", [
+          "https://example.com",
+          "https://another.com"
+        ])
+
+      config = Keyword.put(config, :openid_configuration, openid_config)
+      id_token = gen_id_token(alg: "HS256", iss: "http://localhost")
+
+      assert OIDC.validate_id_token(config, id_token) ==
+               {:error, "Invalid issuer \"http://localhost\" in ID Token"}
+    end
+
     test "with unexpected `alg`", %{config: config, id_token: id_token} do
       assert OIDC.validate_id_token(
                Keyword.delete(config, :id_token_signed_response_alg),


### PR DESCRIPTION
- Add validate_issuer_identifier clause to handle list of issuers
- Add tests for valid and invalid issuer from list scenarios