### PR TITLE
Preserve request path case in OAuth signature base string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Now requires Elixir 1.15 / OTP 26.
 * `Assent.JWTAdapter.AssentJWT` now supports EdDSA algorithms
 * `Assent.JWTAdapter.AssentJWT` now supports EC JWKs
 
+### Bug fixes
+
+* `Assent.Strategy.OAuth` no longer lowercases the request path for signature base string, per RFC 5849 3.4.1.2
+
 ## v0.3.1 (2025-06-20)
 
 ### Bug fixes

--- a/lib/assent/strategies/oauth.ex
+++ b/lib/assent/strategies/oauth.ex
@@ -290,9 +290,12 @@ defmodule Assent.Strategy.OAuth do
       |> String.upcase()
 
     base_string_uri =
-      %{uri | query: nil, host: uri.host}
-      |> URI.to_string()
-      |> String.downcase()
+      URI.to_string(%{
+        uri
+        | query: nil,
+          scheme: String.downcase(uri.scheme),
+          host: String.downcase(uri.host)
+      })
 
     normalized_request_params =
       request_params

--- a/test/assent/strategies/oauth_test.exs
+++ b/test/assent/strategies/oauth_test.exs
@@ -634,12 +634,12 @@ defmodule Assent.Strategy.OAuthTest do
       assert response.body == %{"success" => true}
     end
 
-    test "with uppercase url", %{config: config, token: token} do
+    test "with uppercase scheme and host", %{config: config, token: token} do
       shared_secret = "#{config[:consumer_secret]}&#{token["oauth_token_secret"]}"
       config = Keyword.put(config, :base_url, String.upcase(config[:base_url]))
-      info_url = TestServer.url("/info")
+      info_url = TestServer.url("/Info")
 
-      expect_oauth_api_request("/INFO", %{"success" => true}, [], fn _conn, oauth_params ->
+      expect_oauth_api_request("/Info", %{"success" => true}, [], fn _conn, oauth_params ->
         signature_base_string =
           gen_signature_base_string("GET&#{URI.encode_www_form(info_url)}&", oauth_params)
 
@@ -649,7 +649,9 @@ defmodule Assent.Strategy.OAuthTest do
         assert :crypto.mac(:hmac, :sha, shared_secret, signature_base_string) == decoded_signature
       end)
 
-      assert {:ok, response} = OAuth.request(config, token, :get, "/INFO")
+      # Per RFC 5849 §3.4.1.2 the host and scheme should be case-insensitive
+      refute String.starts_with?(info_url, config[:base_url])
+      assert {:ok, response} = OAuth.request(config, token, :get, "/Info")
       assert response.body == %{"success" => true}
     end
 


### PR DESCRIPTION
Rare edge case but request path should be case insensitive per the spec.