### PR TITLE
Normalize response header names in Assent.HTTPAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Now requires Elixir 1.15 / OTP 26.
 ### Bug fixes
 
 * `Assent.Strategy.OAuth` no longer lowercases the request path for signature base string, per RFC 5849 3.4.1.2
+* `Assent.HTTPAdapter.Req` now returns the response headers instead of the request headers
 
 ## v0.3.1 (2025-06-20)
 

--- a/lib/assent/http_adapter.ex
+++ b/lib/assent/http_adapter.ex
@@ -103,7 +103,9 @@ defmodule Assent.HTTPAdapter do
     |> http_adapter.request(url, body, headers, http_adapter_opts)
     |> case do
       {:ok, response} ->
-        decode_response(response, opts)
+        response
+        |> normalize_headers()
+        |> decode_response(opts)
 
       {:error, error} ->
         {:error,
@@ -140,6 +142,10 @@ defmodule Assent.HTTPAdapter do
       true -> {Assent.HTTPAdapter.Req, []}
       false -> {Assent.HTTPAdapter.Httpc, []}
     end
+  end
+
+  defp normalize_headers(%HTTPResponse{headers: headers} = response) do
+    %{response | headers: Enum.map(headers, fn {key, value} -> {String.downcase(key), value} end)}
   end
 
   @doc """

--- a/lib/assent/http_adapter/httpc.ex
+++ b/lib/assent/http_adapter/httpc.ex
@@ -79,11 +79,7 @@ if Code.ensure_loaded?(:httpc) do
     end
 
     defp format_response({:ok, {{_, status, _}, headers, body}}) do
-      headers =
-        Enum.map(headers, fn {key, value} ->
-          {String.downcase(to_string(key)), to_string(value)}
-        end)
-
+      headers = for {key, value} <- headers, do: {to_string(key), to_string(value)}
       body = IO.iodata_to_binary(body)
 
       {:ok, %HTTPResponse{status: status, headers: headers, body: body}}

--- a/lib/assent/http_adapter/req.ex
+++ b/lib/assent/http_adapter/req.ex
@@ -34,10 +34,7 @@ if Code.ensure_loaded?(Req) do
       |> Req.request()
       |> case do
         {:ok, response} ->
-          headers =
-            Enum.map(headers, fn {key, value} ->
-              {String.downcase(to_string(key)), to_string(value)}
-            end)
+          headers = for {key, values} <- response.headers, value <- values, do: {key, value}
 
           {:ok, %HTTPResponse{status: response.status, headers: headers, body: response.body}}
 

--- a/test/assent/http_adapter/httpc_test.exs
+++ b/test/assent/http_adapter/httpc_test.exs
@@ -102,6 +102,22 @@ defmodule Assent.HTTPAdapter.HttpcTest do
                Httpc.request(:get, TestServer.url("/get?a=1"), nil, [])
     end
 
+    test "with response headers" do
+      TestServer.add("/",
+        via: :get,
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("x-header", "value")
+          |> Plug.Conn.send_resp(200, "")
+        end
+      )
+
+      assert {:ok, %HTTPResponse{headers: headers}} =
+               Httpc.request(:get, TestServer.url(), nil, [])
+
+      assert {"x-header", "value"} in headers
+    end
+
     test "with POST request" do
       TestServer.add("/post",
         via: :post,

--- a/test/assent/http_adapter/req_test.exs
+++ b/test/assent/http_adapter/req_test.exs
@@ -30,6 +30,22 @@ defmodule Assent.HTTPAdapter.ReqTest do
                Req.request(:get, url, nil, [], retry: false)
     end
 
+    test "with response headers" do
+      TestServer.add("/",
+        via: :get,
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("x-header", "value")
+          |> Plug.Conn.send_resp(200, "")
+        end
+      )
+
+      assert {:ok, %HTTPResponse{headers: headers}} =
+               Req.request(:get, TestServer.url(), nil, [], @req_opts)
+
+      assert {"x-header", "value"} in headers
+    end
+
     test "with POST request" do
       TestServer.add("/post",
         via: :post,

--- a/test/assent/http_adapter_test.exs
+++ b/test/assent/http_adapter_test.exs
@@ -51,6 +51,15 @@ defmodule Assent.HTTPAdapterTest do
       {:ok, %HTTPResponse{status: 200, headers: [], body: @json_library.encode!(%{"a" => 1})}}
     end
 
+    def request(:get, "uppercase-header-names", nil, [], nil) do
+      {:ok,
+       %HTTPResponse{
+         status: 200,
+         headers: [{"Content-Type", "application/json"}],
+         body: @json_library.encode!(%{"a" => 1})
+       }}
+    end
+
     def request(:get, "form-data-body", nil, [], nil) do
       {:ok,
        %HTTPResponse{
@@ -138,6 +147,16 @@ defmodule Assent.HTTPAdapterTest do
                 body: @json_library.encode!(%{"a" => 1}),
                 http_adapter: HTTPMock,
                 request_url: "json-no-headers"
+              }}
+
+    assert HTTPAdapter.request(:get, "uppercase-header-names", nil, [], http_adapter: HTTPMock) ==
+             {:ok,
+              %HTTPResponse{
+                status: 200,
+                headers: [{"content-type", "application/json"}],
+                body: %{"a" => 1},
+                http_adapter: HTTPMock,
+                request_url: "uppercase-header-names"
               }}
 
     assert HTTPAdapter.request(:get, "form-data-body", nil, [], http_adapter: HTTPMock) ==


### PR DESCRIPTION
This came from fixing req issue where it returned request headers instead of response headers. Pushes normalization into one spot in case some HTTP client doesn't downcase the headers.