### PR TITLE
Add normalize_access_token/1 callback to OAuth2.Base

### DIFF
--- a/lib/assent/strategies/oauth2.ex
+++ b/lib/assent/strategies/oauth2.ex
@@ -316,7 +316,21 @@ defmodule Assent.Strategy.OAuth2 do
 
       :post
       |> Helpers.http_request(url, body, headers, config)
-      |> process_access_token_response()
+      |> process_access_token_response(config)
+    end
+  end
+
+  # A strategy built on `OAuth2.Base` may reshape a non-standard token-response
+  # body (e.g. one wrapped in an envelope) via `normalize_access_token/1` before
+  # it is matched. `config[:strategy]` is set by `OAuth2.Base`; a strategy used
+  # directly (no `:strategy`) is unaffected.
+  defp normalize_access_token_body(body, config) do
+    strategy = Keyword.get(config, :strategy)
+
+    if strategy && function_exported?(strategy, :normalize_access_token, 1) do
+      strategy.normalize_access_token(body)
+    else
+      {:ok, body}
     end
   end
 
@@ -402,13 +416,18 @@ defmodule Assent.Strategy.OAuth2 do
   end
 
   defp process_access_token_response(
-         {:ok, %HTTPResponse{status: status, body: %{"access_token" => _} = token}}
+         {:ok, %HTTPResponse{status: status, body: body} = response},
+         config
        )
-       when status in [200, 201] do
-    {:ok, token}
+       when status in [200, 201] and is_map(body) do
+    case normalize_access_token_body(body, config) do
+      {:ok, %{"access_token" => _} = token} -> {:ok, token}
+      {:ok, _other} -> process_response({:ok, response})
+      {:error, error} -> {:error, error}
+    end
   end
 
-  defp process_access_token_response(any), do: process_response(any)
+  defp process_access_token_response(any, _config), do: process_response(any)
 
   defp process_response({:ok, %HTTPResponse{} = response}),
     do: {:error, UnexpectedResponseError.exception(response: response)}

--- a/lib/assent/strategies/oauth2/base.ex
+++ b/lib/assent/strategies/oauth2/base.ex
@@ -31,6 +31,20 @@ defmodule Assent.Strategy.OAuth2.Base do
           }
         end
       end
+
+  ## Non-standard token responses
+
+  Some providers wrap the token response in an envelope rather than returning
+  the OAuth2-standard `{"access_token": ...}` object at the top level. Override
+  `normalize_access_token/1` to reshape the decoded response body before it is
+  processed:
+
+      @impl true
+      def normalize_access_token(%{"data" => token}), do: {:ok, token}
+      def normalize_access_token(token), do: {:ok, token}
+
+  It defaults to the identity function, so standard providers need not
+  implement it.
   """
   alias Assent.Strategy, as: Helpers
   alias Assent.Strategy.OAuth2
@@ -38,6 +52,7 @@ defmodule Assent.Strategy.OAuth2.Base do
   @callback default_config(Keyword.t()) :: Keyword.t()
   @callback normalize(Keyword.t(), map()) :: {:ok, map()} | {:ok, map(), map()} | {:error, term()}
   @callback fetch_user(Keyword.t(), map()) :: {:ok, map()} | {:error, term()}
+  @callback normalize_access_token(map()) :: {:ok, map()} | {:error, term()}
 
   @doc false
   defmacro __using__(_opts) do
@@ -55,6 +70,9 @@ defmodule Assent.Strategy.OAuth2.Base do
 
       @impl unquote(__MODULE__)
       def fetch_user(config, token), do: OAuth2.fetch_user(config, token)
+
+      @impl unquote(__MODULE__)
+      def normalize_access_token(response_body), do: {:ok, response_body}
 
       defoverridable unquote(__MODULE__)
     end

--- a/test/assent/strategies/oauth2/base_test.exs
+++ b/test/assent/strategies/oauth2/base_test.exs
@@ -1,0 +1,55 @@
+defmodule Assent.Strategy.OAuth2.BaseTest do
+  use Assent.Test.OAuth2TestCase
+
+  defmodule EnvelopeStrategy do
+    @moduledoc false
+    use Assent.Strategy.OAuth2.Base
+
+    @impl true
+    def default_config(_config), do: [auth_method: :client_secret_post, user_url: "/api/user"]
+
+    @impl true
+    def normalize(_config, user), do: {:ok, user}
+
+    # Unwrap a non-standard `{"data": {...}}` token-response envelope.
+    @impl true
+    def normalize_access_token(%{"data" => token}) when is_map(token), do: {:ok, token}
+    def normalize_access_token(token), do: {:ok, token}
+  end
+
+  describe "callback/2 with normalize_access_token/1" do
+    test "unwraps an enveloped token response before it is processed", %{
+      config: config,
+      callback_params: params
+    } do
+      # The token endpoint returns the access token wrapped in a `data`
+      # envelope — not the OAuth2-standard top-level shape.
+      expect_oauth2_access_token_request(
+        params: %{"data" => %{"access_token" => "wrapped_token"}}
+      )
+
+      expect_oauth2_user_request(%{"id" => "1", "email" => "a@b.example"},
+        access_token: "wrapped_token"
+      )
+
+      assert {:ok, %{user: user, token: token}} = EnvelopeStrategy.callback(config, params)
+
+      # The wrapped token was unwrapped and used to fetch the user.
+      assert token["access_token"] == "wrapped_token"
+      assert user["email"] == "a@b.example"
+    end
+
+    test "defaults to identity for a standard token response", %{
+      config: config,
+      callback_params: params
+    } do
+      # A standard (non-enveloped) token response is unaffected by the default
+      # `normalize_access_token/1`.
+      expect_oauth2_access_token_request(params: %{"access_token" => "plain_token"})
+      expect_oauth2_user_request(%{"id" => "1"}, access_token: "plain_token")
+
+      assert {:ok, %{token: token}} = EnvelopeStrategy.callback(config, params)
+      assert token["access_token"] == "plain_token"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

A strategy built on `Assent.Strategy.OAuth2.Base` can reshape the **profile** response via `normalize/2`, but there is no equivalent for the **token** response.

Some providers wrap their token response in an envelope rather than returning the OAuth2-standard `{"access_token": ...}` object at the top level — e.g. a JSON:API-style `{"data": {"access_token": ...}}`. `OAuth2.grant_access_token/3` processes the response with a private function that matches the standard shape directly, so such a provider can't be expressed as a `Base` strategy — it has to reimplement the whole OAuth2 flow just to unwrap the token.

(Concretely, this came up integrating [Ed.link](https://ed.link), which wraps both its token and profile responses in a `$data` envelope. The profile side is handled cleanly by `normalize/2`; the token side had no hook.)

## Change

Add a `normalize_access_token/1` callback to `OAuth2.Base`, mirroring `normalize/2`. It receives the decoded token-response body and returns the (possibly reshaped) token map, which is then matched as usual:

```elixir
@impl true
def normalize_access_token(%{"data" => token}), do: {:ok, token}
def normalize_access_token(token), do: {:ok, token}
```

- **Defaults to identity** — standard providers need not implement it.
- **Opt-in per strategy** — only consulted when the strategy defines it (via `config[:strategy]`, which `OAuth2.Base` already sets, guarded by `function_exported?/3`). `OAuth2` used directly, and OIDC-based strategies, are unaffected.
- Documented on `OAuth2.Base` next to `normalize/2`.

## Tests

New `oauth2/base_test.exs` covers the enveloped-response unwrap and the default-identity path. The full suite passes (**301 tests**), including all built-in strategies (Google, GitHub, OIDC, …).

## Compatibility

Backward-compatible: no signature changes to public functions, default behaviour unchanged, and the hook is skipped for any strategy that doesn't implement it.